### PR TITLE
Fix scad Haribo nozzle scad and corresponding STL - Rotate 180 degrees

### DIFF
--- a/STL/optional/1x_fan-nozzle-haribo.scad
+++ b/STL/optional/1x_fan-nozzle-haribo.scad
@@ -1,44 +1,40 @@
 module fan_nozzle(){
+    difference(){    
+        union(){
+            cube([32,10,17]); // Main cube
+            translate([30,5,0])cylinder(r=5.8,h = 17, $fn=6);    
+            translate([-3,0,-6]) cube([3,10,23]);
+            //#translate([-2,5,0])cylinder(r=5.8,h = 17, $fn=6);        
+        }
+
+        // Mounting screw
+        translate([30,5,-10])cylinder(r=3.2/2,h = 24.5-0.2, $fn=15); // Screw cut
+        translate([30,5,17-3.5])cylinder(r=3.1,h = 20, $fn=15); // head cut
+
+        //#translate([-2,5,-10])cylinder(r=3.2/2,h = 24.5-0.2, $fn=15); // Screw cut
+        //#translate([-2,5,17-3.5])cylinder(r=3.1,h = 20, $fn=15); // head cut
+
+        // Fan entry hole
+        translate([1,10-1.5,-1])cube([20,3,16.5]);
+        translate([1,10-1.5,-1-5])cube([18,3,16.5]);
     
-difference(){    
-union(){
-cube([32,10,17]); // Main cube
-translate([30,5,0])cylinder(r=5.8,h = 17, $fn=6);    
-translate([-3,0,-6]) cube([3,10,23]);
-//#translate([-2,5,0])cylinder(r=5.8,h = 17, $fn=6);        
-}
-// Mounting screw
-translate([30,5,-10])cylinder(r=3.2/2,h = 24.5-0.2, $fn=15); // Screw cut
-translate([30,5,17-3.5])cylinder(r=3.1,h = 20, $fn=15); // head cut
+        // Airway cutout
+        difference(){    
+            translate([1,1,-1])cube([25,8,16.5]);    
+            translate([0,0,10])rotate([45,0,0])cube([30,8,16.5]);    
+            translate([-1,-10,-1])rotate([0,0,45])cube([10,8,30]); 
+            translate([20,0,16])rotate([0,20,0])cube([10,20,10]);    
+        }
+        translate([2,-1,-4.5])cube([24,3,5]);
+        //#translate([-2,-1,-2])rotate([0,45,0])cube([5,10,5]);
+        translate([22,-1,-2])rotate([0,45,0])cube([5,10,5]);
+    }
 
-//#translate([-2,5,-10])cylinder(r=3.2/2,h = 24.5-0.2, $fn=15); // Screw cut
-//#translate([-2,5,17-3.5])cylinder(r=3.1,h = 20, $fn=15); // head cut
-
-// Fan entry hole
-translate([1,10-1.5,-1])cube([20,3,16.5]);
-translate([1,10-1.5,-1-5])cube([18,3,16.5]);
-    
-// Airway cutout
-difference(){    
-translate([1,1,-1])cube([25,8,16.5]);    
-translate([0,0,10])rotate([45,0,0])cube([30,8,16.5]);    
-translate([-1,-10,-1])rotate([0,0,45])cube([10,8,30]); 
-translate([20,0,16])rotate([0,20,0])cube([10,20,10]);    
-}
-translate([2,-1,-4.5])cube([24,3,5]);
-//#translate([-2,-1,-2])rotate([0,45,0])cube([5,10,5]);
-translate([22,-1,-2])rotate([0,45,0])cube([5,10,5]);
-    
-}
-
-// Air director
-translate([18,0,7])rotate([0,0,30])cube([1,9,10]);
-
-
+    // Air director
+    translate([18,0,7])rotate([0,0,30])cube([1,9,10]);
 }
 
 module fancy_corners(){
-    
     translate([-10,-10.5,13])rotate([-20,0,0])cube([50,10,15]);
     translate([-16,-10.5,17.5])rotate([0,45,0])cube([10,30,15]);
     
@@ -54,14 +50,16 @@ module fancy_corners(){
     translate([-7,-5,12])rotate([0,-45,0])cube([10,30,15]);
     
     translate([-7,5,-10])rotate([0,0,45])cube([10,10,35]);
-    
-    }
+}
 
 module fan_n(){
-difference(){
-fan_nozzle();
-fancy_corners();    
-translate([-1,3.5,16.5])linear_extrude(height = 0.6) {text("HARIBO", size = 5, font = "Helvetica Neue:style=Bold");}
+    difference(){
+        fan_nozzle();
+        fancy_corners();    
+        translate([-1,3.5,16.5])linear_extrude(height = 0.6){
+            text("HARIBO", size = 5, font = "Helvetica Neue:style=Bold");
+        }
+    }
 }
-}
+
 fan_n();

--- a/STL/optional/1x_fan-nozzle-haribo.scad
+++ b/STL/optional/1x_fan-nozzle-haribo.scad
@@ -62,4 +62,10 @@ module fan_n(){
     }
 }
 
-fan_n();
+module printable_fan_n() {
+    rotate([0,180,0]){
+        fan_n();
+    }
+}
+
+printable_fan_n();

--- a/STL/optional/1x_fan-nozzle-haribo.stl
+++ b/STL/optional/1x_fan-nozzle-haribo.stl
@@ -1,6638 +1,6638 @@
 solid OpenSCAD_Model
-  facet normal 0 0 1
-    outer loop
-      vertex 2.57899 6.37999 17
-      vertex 0.472992 8.29999 17
-      vertex 0.472992 6.37999 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 2.57899 5.549 17
-      vertex 0.472992 5.549 17
-      vertex 2.57899 3.5 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 32.832 3.73912 17
-      vertex 35.2506 4.98453 17
-      vertex 33.1 5 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 35.2506 4.98453 17
-      vertex 32.832 6.26088 17
-      vertex 33.1 5 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 32.3417 10.0229 17
-      vertex 32.832 6.26088 17
-      vertex 35.2506 4.98453 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 32.3417 10.0229 17
-      vertex 32.0743 7.30375 17
-      vertex 32.832 6.26088 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 32.3417 10.0229 17
-      vertex 30.958 7.94827 17
-      vertex 32.0743 7.30375 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 32.3417 10.0229 17
-      vertex 29.676 8.08302 17
-      vertex 30.958 7.94827 17
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 27.1 10.0229 17
-      vertex 29.676 8.08302 17
-      vertex 32.3417 10.0229 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 29.676 8.08302 17
-      vertex 27.1 10.0229 17
-      vertex 28.45 7.68468 17
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 27.0868 10 17
-      vertex 28.45 7.68468 17
-      vertex 27.1 10.0229 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 28.45 7.68468 17
-      vertex 27.0868 10 17
-      vertex 27.492 6.82213 17
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 25.432 7.22221 17
-      vertex 27.492 6.82213 17
-      vertex 27.0868 10 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 25.6853 5.44188 17
-      vertex 26.9677 5.64453 17
-      vertex 25.7183 5.92 17
-    endloop
-  endfacet
-  facet normal 0 -0 1
-    outer loop
-      vertex 25.6467 6.62521 17
-      vertex 27.492 6.82213 17
-      vertex 25.432 7.22221 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 26.9677 5.64453 17
-      vertex 25.6467 6.62521 17
-      vertex 25.7183 5.92 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 27.492 6.82213 17
-      vertex 25.6467 6.62521 17
-      vertex 26.9677 5.64453 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 27.0868 10 17
-      vertex 25.0743 7.711 17
-      vertex 25.432 7.22221 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 27.0868 10 17
-      vertex 24.5899 8.07378 17
-      vertex 25.0743 7.711 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 27.0868 10 17
-      vertex 23.9943 8.29144 17
-      vertex 24.5899 8.07378 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 27.0868 10 17
-      vertex 23.2873 8.364 17
-      vertex 23.9943 8.29144 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 27.0868 10 17
-      vertex 22.5804 8.29222 17
-      vertex 23.2873 8.364 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.8657 8.26633 17
-      vertex 22.5804 8.29222 17
-      vertex 27.0868 10 17
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 20.012 6.61665 17
-      vertex 20.8593 5.92 17
-      vertex 20.9306 6.63222 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.8593 5.92 17
-      vertex 20.3562 5.18466 17
-      vertex 20.3903 4.877 17
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 20.1133 7.10199 17
-      vertex 20.9306 6.63222 17
-      vertex 21.1446 7.23155 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.8593 5.92 17
-      vertex 20.2539 5.44899 17
-      vertex 20.3562 5.18466 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.9306 6.63222 17
-      vertex 20.1133 7.10199 17
-      vertex 20.088 6.84532 17
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 20.063 7.46455 17
-      vertex 21.1446 7.23155 17
-      vertex 21.5013 7.71799 17
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 19.6603 7.99699 17
-      vertex 21.5013 7.71799 17
-      vertex 21.985 8.07687 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.1446 7.23155 17
-      vertex 20.063 7.46455 17
-      vertex 20.1133 7.10199 17
-    endloop
-  endfacet
-  facet normal 0 -0 1
-    outer loop
-      vertex 19.3107 8.16533 17
-      vertex 22.5804 8.29222 17
-      vertex 18.8657 8.26633 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.5013 7.71799 17
-      vertex 19.912 7.76288 17
-      vertex 20.063 7.46455 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.5013 7.71799 17
-      vertex 19.6603 7.99699 17
-      vertex 19.912 7.76288 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.985 8.07687 17
-      vertex 19.3107 8.16533 17
-      vertex 19.6603 7.99699 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 22.5804 8.29222 17
-      vertex 19.3107 8.16533 17
-      vertex 21.985 8.07687 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 27.0868 10 17
-      vertex 18.3253 8.29999 17
-      vertex 18.8657 8.26633 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 27.0868 10 17
-      vertex 16.1203 8.29999 17
-      vertex 18.3253 8.29999 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 16.1203 8.29999 17
-      vertex 15.2268 8.29999 17
-      vertex 16.1203 3.5 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 27.0868 10 17
-      vertex 15.2268 8.29999 17
-      vertex 16.1203 8.29999 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 27.0868 10 17
-      vertex 14.2218 8.29999 17
-      vertex 15.2268 8.29999 17
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 13.4808 6.52899 17
-      vertex 14.2218 3.5 17
-      vertex 14.2218 8.29999 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.4808 6.52899 17
-      vertex 14.2218 8.29999 17
-      vertex 13.5128 6.853 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.2218 8.29999 17
-      vertex 13.4607 7.28333 17
-      vertex 13.5128 6.853 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.2218 8.29999 17
-      vertex 13.3044 7.64099 17
-      vertex 13.4607 7.28333 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.2218 8.29999 17
-      vertex 13.0438 7.92599 17
-      vertex 13.3044 7.64099 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.2218 8.29999 17
-      vertex 12.6882 8.13377 17
-      vertex 13.0438 7.92599 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.7148 8.29999 17
-      vertex 14.2218 8.29999 17
-      vertex 27.0868 10 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.2218 8.29999 17
-      vertex 12.2452 8.25844 17
-      vertex 12.6882 8.13377 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.2218 8.29999 17
-      vertex 11.7148 8.29999 17
-      vertex 12.2452 8.25844 17
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex -2 10 17
-      vertex 11.7148 8.29999 17
-      vertex 27.0868 10 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 9.30783 8.29999 17
-      vertex 8.54492 3.5 17
-      vertex 9.30783 3.5 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 9.30783 8.29999 17
-      vertex 6.91092 8.29999 17
-      vertex 8.54492 3.5 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.7148 8.29999 17
-      vertex -2 10 17
-      vertex 9.30783 8.29999 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 9.30783 8.29999 17
-      vertex -2 10 17
-      vertex 6.91092 8.29999 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 5.72592 8.29999 17
-      vertex 3.584 8.29999 17
-      vertex 4.08591 3.5 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 6.91092 8.29999 17
-      vertex -2 10 17
-      vertex 5.72592 8.29999 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 5.72592 8.29999 17
-      vertex -2 10 17
-      vertex 3.584 8.29999 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 2.57899 8.29999 17
-      vertex 0.472992 8.29999 17
-      vertex 2.57899 6.37999 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 3.584 8.29999 17
-      vertex -2 10 17
-      vertex 2.57899 8.29999 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 2.57899 8.29999 17
-      vertex -2 10 17
-      vertex 0.472992 8.29999 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -2 10 17
-      vertex -0.532013 3.5 17
-      vertex -0.532013 8.29999 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 0.472992 8.29999 17
-      vertex -2 10 17
-      vertex -0.532013 8.29999 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -0.532013 3.5 17
-      vertex -2 10 17
-      vertex -2 1.64214 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -0.532013 3.5 17
-      vertex -2 1.64214 17
-      vertex -1.95552 1.59766 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 35.2506 4.98453 17
-      vertex 32.832 3.73912 17
-      vertex 33.2952 1.59766 17
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 32.0743 2.69625 17
-      vertex 33.2952 1.59766 17
-      vertex 32.832 3.73912 17
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 30.958 2.05172 17
-      vertex 33.2952 1.59766 17
-      vertex 32.0743 2.69625 17
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 29.676 1.91698 17
-      vertex 33.2952 1.59766 17
-      vertex 30.958 2.05172 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 25.5863 5.00356 17
-      vertex 26.9677 5.64453 17
-      vertex 25.6853 5.44188 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 26.9677 5.64453 17
-      vertex 25.5863 5.00356 17
-      vertex 26.9677 4.35547 17
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 25.4213 4.605 17
-      vertex 26.9677 4.35547 17
-      vertex 25.5863 5.00356 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 25.1948 4.25655 17
-      vertex 26.9677 4.35547 17
-      vertex 25.4213 4.605 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 26.9677 4.35547 17
-      vertex 25.1948 4.25655 17
-      vertex 27.492 3.17787 17
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 24.9115 3.96721 17
-      vertex 27.492 3.17787 17
-      vertex 25.1948 4.25655 17
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 24.5713 3.737 17
-      vertex 27.492 3.17787 17
-      vertex 24.9115 3.96721 17
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 24.182 3.56976 17
-      vertex 27.492 3.17787 17
-      vertex 24.5713 3.737 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 27.492 3.17787 17
-      vertex 24.182 3.56976 17
-      vertex 28.45 2.31532 17
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 23.7517 3.46945 17
-      vertex 28.45 2.31532 17
-      vertex 24.182 3.56976 17
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 23.2803 3.436 17
-      vertex 28.45 2.31532 17
-      vertex 23.7517 3.46945 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.0711 3.53999 17
-      vertex 28.45 2.31532 17
-      vertex 23.2803 3.436 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.0711 3.53999 17
-      vertex 23.2803 3.436 17
-      vertex 22.5787 3.50977 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.3903 4.877 17
-      vertex 20.9307 5.20444 17
-      vertex 20.8593 5.92 17
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 20.3903 4.877 17
-      vertex 21.145 4.59776 17
-      vertex 20.9307 5.20444 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.3356 4.47198 17
-      vertex 21.145 4.59776 17
-      vertex 20.3903 4.877 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.1712 4.133 17
-      vertex 21.145 4.59776 17
-      vertex 20.3356 4.47198 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.145 4.59776 17
-      vertex 20.1712 4.133 17
-      vertex 21.5023 4.09999 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.8973 3.85999 17
-      vertex 21.5023 4.09999 17
-      vertex 20.1712 4.133 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.5023 4.09999 17
-      vertex 19.8973 3.85999 17
-      vertex 21.986 3.73111 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.5268 3.65999 17
-      vertex 21.986 3.73111 17
-      vertex 19.8973 3.85999 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.986 3.73111 17
-      vertex 19.5268 3.65999 17
-      vertex 22.5787 3.50977 17
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 19.0711 3.53999 17
-      vertex 22.5787 3.50977 17
-      vertex 19.5268 3.65999 17
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 18.5303 3.5 17
-      vertex 28.45 2.31532 17
-      vertex 19.0711 3.53999 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 28.45 2.31532 17
-      vertex 18.5303 3.5 17
-      vertex 29.676 1.91698 17
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 16.1203 3.5 17
-      vertex 29.676 1.91698 17
-      vertex 18.5303 3.5 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 15.2268 3.5 17
-      vertex 16.1203 3.5 17
-      vertex 15.2268 8.29999 17
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 15.2268 3.5 17
-      vertex 29.676 1.91698 17
-      vertex 16.1203 3.5 17
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 14.2218 3.5 17
-      vertex 29.676 1.91698 17
-      vertex 15.2268 3.5 17
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 13.7518 3.5 17
-      vertex 29.676 1.91698 17
-      vertex 14.2218 3.5 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -1.95552 1.59766 17
-      vertex 13.7518 3.5 17
-      vertex 12.6208 3.5 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.3128 3.5 17
-      vertex 11.5018 5.29199 17
-      vertex 10.3128 5.29199 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.5018 5.29199 17
-      vertex 10.3128 3.5 17
-      vertex 12.6208 3.5 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -1.95552 1.59766 17
-      vertex 12.6208 3.5 17
-      vertex 10.3128 3.5 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.7518 3.5 17
-      vertex -1.95552 1.59766 17
-      vertex 29.676 1.91698 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -1.95552 1.59766 17
-      vertex 10.3128 3.5 17
-      vertex 9.30783 3.5 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -1.95552 1.59766 17
-      vertex 9.30783 3.5 17
-      vertex 8.54492 3.5 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -1.95552 1.59766 17
-      vertex 8.54492 3.5 17
-      vertex 7.54991 3.5 17
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 5.48091 4.728 17
-      vertex 7.54991 3.5 17
-      vertex 7.15892 4.728 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 5.09091 3.5 17
-      vertex 7.54991 3.5 17
-      vertex 5.48091 4.728 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -1.95552 1.59766 17
-      vertex 7.54991 3.5 17
-      vertex 5.09091 3.5 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -1.95552 1.59766 17
-      vertex 5.09091 3.5 17
-      vertex 4.08591 3.5 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 3.584 3.5 17
-      vertex 4.08591 3.5 17
-      vertex 3.584 8.29999 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -1.95552 1.59766 17
-      vertex 4.08591 3.5 17
-      vertex 3.584 3.5 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -1.95552 1.59766 17
-      vertex 3.584 3.5 17
-      vertex 2.57899 3.5 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 0.472992 3.5 17
-      vertex 2.57899 3.5 17
-      vertex 0.472992 5.549 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -1.95552 1.59766 17
-      vertex 2.57899 3.5 17
-      vertex 0.472992 3.5 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex -1.95552 1.59766 17
-      vertex 0.472992 3.5 17
-      vertex -0.532013 3.5 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 29.676 1.91698 17
-      vertex -1.95552 1.59766 17
-      vertex 33.2952 1.59766 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.9306 6.63222 17
-      vertex 20.088 6.84532 17
-      vertex 20.012 6.61665 17
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 19.8853 6.41599 17
-      vertex 20.8593 5.92 17
-      vertex 20.012 6.61665 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.8593 5.92 17
-      vertex 20.0833 5.67 17
-      vertex 20.2539 5.44899 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 20.8593 5.92 17
-      vertex 19.8853 6.41599 17
-      vertex 20.0833 5.67 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.8853 6.41599 17
-      vertex 19.8483 5.84433 17
-      vertex 20.0833 5.67 17
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 19.7074 6.25011 17
-      vertex 19.8483 5.84433 17
-      vertex 19.8853 6.41599 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.7074 6.25011 17
-      vertex 19.5513 5.96733 17
-      vertex 19.8483 5.84433 17
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 19.4764 6.12444 17
-      vertex 19.5513 5.96733 17
-      vertex 19.7074 6.25011 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.5513 5.96733 17
-      vertex 19.4764 6.12444 17
-      vertex 19.1923 6.03899 17
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 13.3848 6.23566 17
-      vertex 14.2218 3.5 17
-      vertex 13.4808 6.52899 17
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 13.2248 5.97299 17
-      vertex 14.2218 3.5 17
-      vertex 13.3848 6.23566 17
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 13.0111 5.75444 17
-      vertex 14.2218 3.5 17
-      vertex 13.2248 5.97299 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 14.2218 3.5 17
-      vertex 13.0111 5.75444 17
-      vertex 13.7518 3.5 17
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 12.7524 5.5921 17
-      vertex 13.7518 3.5 17
-      vertex 13.0111 5.75444 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 13.7518 3.5 17
-      vertex 12.7524 5.5921 17
-      vertex 12.4488 5.48599 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 6.22391 7.20699 17
-      vertex 6.38391 7.32599 17
-      vertex 6.31792 7.56099 17
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 6.22391 7.20699 17
-      vertex 6.51791 6.86299 17
-      vertex 6.38391 7.32599 17
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 6.14514 6.94577 17
-      vertex 6.51791 6.86299 17
-      vertex 6.22391 7.20699 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 5.68692 5.48399 17
-      vertex 6.51791 6.86299 17
-      vertex 6.14514 6.94577 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 6.51791 6.86299 17
-      vertex 5.68692 5.48399 17
-      vertex 6.95291 5.48399 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.1128 6.15866 17
-      vertex 12.4774 6.59633 17
-      vertex 12.5018 6.81299 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.1054 7.44144 17
-      vertex 12.5018 6.81299 17
-      vertex 12.4027 7.20576 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.8978 6.09366 17
-      vertex 12.5018 6.81299 17
-      vertex 12.1054 7.44144 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.4774 6.59633 17
-      vertex 12.1128 6.15866 17
-      vertex 12.4041 6.41432 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.4041 6.41432 17
-      vertex 12.1128 6.15866 17
-      vertex 12.2818 6.267 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 12.5018 6.81299 17
-      vertex 11.8978 6.09366 17
-      vertex 12.1128 6.15866 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.6098 7.51999 17
-      vertex 11.8978 6.09366 17
-      vertex 12.1054 7.44144 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.8978 6.09366 17
-      vertex 11.6098 7.51999 17
-      vertex 11.6368 6.07199 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 10.3128 6.07199 17
-      vertex 11.6098 7.51999 17
-      vertex 10.3128 7.51999 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 11.6098 7.51999 17
-      vertex 10.3128 6.07199 17
-      vertex 11.6368 6.07199 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.9788 4.32466 17
-      vertex 19.3573 4.73854 17
-      vertex 19.3823 4.95499 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.9494 5.56122 17
-      vertex 19.3823 4.95499 17
-      vertex 19.2741 5.33388 17
-    endloop
-  endfacet
-  facet normal 0 -0 1
-    outer loop
-      vertex 18.9788 4.32466 17
-      vertex 19.3823 4.95499 17
-      vertex 18.9494 5.56122 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.2823 4.56122 17
-      vertex 18.9788 4.32466 17
-      vertex 19.1573 4.42299 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.3573 4.73854 17
-      vertex 18.9788 4.32466 17
-      vertex 19.2823 4.56122 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.9494 5.56122 17
-      vertex 18.7418 4.26566 17
-      vertex 18.9788 4.32466 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.4083 5.63699 17
-      vertex 18.7418 4.26566 17
-      vertex 18.9494 5.56122 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.7418 4.26566 17
-      vertex 18.4083 5.63699 17
-      vertex 18.4463 4.24599 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 17.1253 4.24599 17
-      vertex 18.4083 5.63699 17
-      vertex 17.1253 5.63699 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.4083 5.63699 17
-      vertex 17.1253 4.24599 17
-      vertex 18.4463 4.24599 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.7339 7.49399 17
-      vertex 19.1023 6.965 17
-      vertex 19.0792 7.15765 17
-    endloop
-  endfacet
-  facet normal 0 -0 1
-    outer loop
-      vertex 18.7529 6.44489 17
-      vertex 19.1023 6.965 17
-      vertex 18.7339 7.49399 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.8943 7.41899 17
-      vertex 19.0792 7.15765 17
-      vertex 19.0099 7.30899 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.0792 7.15765 17
-      vertex 18.8943 7.41899 17
-      vertex 18.7339 7.49399 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.1023 6.965 17
-      vertex 18.7529 6.44489 17
-      vertex 19.0808 6.78644 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 19.0808 6.78644 17
-      vertex 18.9083 6.52599 17
-      vertex 19.0161 6.64011 17
-    endloop
-  endfacet
-  facet normal 0 -0 1
-    outer loop
-      vertex 18.9083 6.52599 17
-      vertex 19.0808 6.78644 17
-      vertex 18.7529 6.44489 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.7339 7.49399 17
-      vertex 18.5452 6.39621 17
-      vertex 18.7529 6.44489 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.5286 7.53899 17
-      vertex 18.5452 6.39621 17
-      vertex 18.7339 7.49399 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.5286 7.53899 17
-      vertex 18.2853 6.37999 17
-      vertex 18.5452 6.39621 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.2783 7.55399 17
-      vertex 18.2853 6.37999 17
-      vertex 18.5286 7.53899 17
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 17.1253 7.55399 17
-      vertex 18.2853 6.37999 17
-      vertex 18.2783 7.55399 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 18.2853 6.37999 17
-      vertex 17.1253 7.55399 17
-      vertex 17.1253 6.37999 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 21.8713 5.92 17
-      vertex 24.6933 5.92 17
-      vertex 24.6521 6.39932 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 24.6933 5.92 17
-      vertex 21.8713 5.92 17
-      vertex 24.6524 5.42032 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 23.2873 7.57399 17
-      vertex 24.6521 6.39932 17
-      vertex 24.5288 6.80399 17
-    endloop
-  endfacet
-  facet normal -0 -0 1
-    outer loop
-      vertex 21.9133 5.43233 17
-      vertex 24.6524 5.42032 17
-      vertex 21.8713 5.92 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 23.6988 7.5251 17
-      vertex 24.5288 6.80399 17
-      vertex 24.3233 7.13399 17
-    endloop
-  endfacet
-  facet normal 0 -0 1
-    outer loop
-      vertex 22.0393 5.01866 17
-      vertex 24.6524 5.42032 17
-      vertex 21.9133 5.43233 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 23.6988 7.5251 17
-      vertex 24.3233 7.13399 17
-      vertex 24.0441 7.37843 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 24.5288 6.80399 17
-      vertex 23.6988 7.5251 17
-      vertex 23.2873 7.57399 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 24.6524 5.42032 17
-      vertex 22.0393 5.01866 17
-      vertex 24.5297 5.00266 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 24.6521 6.39932 17
-      vertex 23.2873 7.57399 17
-      vertex 21.9123 6.40233 17
-    endloop
-  endfacet
-  facet normal 0 -0 1
-    outer loop
-      vertex 23.6977 4.27499 17
-      vertex 24.5297 5.00266 17
-      vertex 23.2803 4.226 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 24.3253 4.66699 17
-      vertex 23.6977 4.27499 17
-      vertex 24.046 4.422 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 22.0353 6.808 17
-      vertex 23.2873 7.57399 17
-      vertex 22.87 7.52544 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 24.5297 5.00266 17
-      vertex 23.6977 4.27499 17
-      vertex 24.3253 4.66699 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 22.2403 7.13699 17
-      vertex 22.87 7.52544 17
-      vertex 22.521 7.37978 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 24.5297 5.00266 17
-      vertex 22.0393 5.01866 17
-      vertex 23.2803 4.226 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 22.87 7.52544 17
-      vertex 22.2403 7.13699 17
-      vertex 22.0353 6.808 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 23.2803 4.226 17
-      vertex 22.0393 5.01866 17
-      vertex 22.8755 4.27632 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 23.2873 7.57399 17
-      vertex 22.0353 6.808 17
-      vertex 21.9123 6.40233 17
-    endloop
-  endfacet
-  facet normal -0 -0 1
-    outer loop
-      vertex 22.2493 4.67899 17
-      vertex 22.8755 4.27632 17
-      vertex 22.0393 5.01866 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 24.6521 6.39932 17
-      vertex 21.9123 6.40233 17
-      vertex 21.8713 5.92 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 22.8755 4.27632 17
-      vertex 22.2493 4.67899 17
-      vertex 22.5318 4.42732 17
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.5513 5.96733 -17
+      vertex -19.4764 6.12444 -17
+      vertex -19.1923 6.03899 -17
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 31.4617 4.34922 0
-      vertex 35.8 5 0
-      vertex 32.9 -0.0229473 0
+      vertex -19.5513 5.96733 -17
+      vertex -19.7074 6.25011 -17
+      vertex -19.4764 6.12444 -17
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 31.4617 5.65078 0
-      vertex 35.8 5 0
-      vertex 31.6 5 0
+      vertex -19.8483 5.84433 -17
+      vertex -19.7074 6.25011 -17
+      vertex -19.5513 5.96733 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.8483 5.84433 -17
+      vertex -19.8853 6.41599 -17
+      vertex -19.7074 6.25011 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.0833 5.67 -17
+      vertex -19.8853 6.41599 -17
+      vertex -19.8483 5.84433 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.8593 5.92 -17
+      vertex -19.8853 6.41599 -17
+      vertex -20.0833 5.67 -17
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 35.8 5 0
-      vertex 31.4617 4.34922 0
-      vertex 31.6 5 0
+      vertex -19.8853 6.41599 -17
+      vertex -20.8593 5.92 -17
+      vertex -20.012 6.61665 -17
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 32.9 -0.0229473 0
-      vertex 31.0706 3.81097 0
-      vertex 31.4617 4.34922 0
+      vertex -20.9306 6.63222 -17
+      vertex -20.012 6.61665 -17
+      vertex -20.8593 5.92 -17
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 32.9 -0.0229473 0
-      vertex 30.4944 3.47831 0
-      vertex 31.0706 3.81097 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 32.9 -0.0229473 0
-      vertex 29.8328 3.40876 0
-      vertex 30.4944 3.47831 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 27.1 -0.0229473 0
-      vertex 29.8328 3.40876 0
-      vertex 32.9 -0.0229473 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 27.0868 0 0
-      vertex 29.8328 3.40876 0
-      vertex 27.1 -0.0229473 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 27.0711 0 0
-      vertex 28.7056 4.05954 0
-      vertex 27.0868 0 0
+      vertex -20.8593 5.92 -17
+      vertex -20.0833 5.67 -17
+      vertex -20.2539 5.44899 -17
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 29.2 3.61436 0
-      vertex 27.0868 0 0
-      vertex 28.7056 4.05954 0
+      vertex -13.3848 6.23566 -17
+      vertex -14.2218 3.5 -17
+      vertex -13.4808 6.52899 -17
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 29.8328 3.40876 0
-      vertex 27.0868 0 0
-      vertex 29.2 3.61436 0
+      vertex -13.2248 5.97299 -17
+      vertex -14.2218 3.5 -17
+      vertex -13.3848 6.23566 -17
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -13.0111 5.75444 -17
+      vertex -14.2218 3.5 -17
+      vertex -13.2248 5.97299 -17
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 35.8 5 0
-      vertex 31.4617 5.65078 0
-      vertex 32.9 10.0229 0
+      vertex -14.2218 3.5 -17
+      vertex -13.0111 5.75444 -17
+      vertex -13.7518 3.5 -17
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -12.7524 5.5921 -17
+      vertex -13.7518 3.5 -17
+      vertex -13.0111 5.75444 -17
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 31.0706 6.18903 0
-      vertex 32.9 10.0229 0
-      vertex 31.4617 5.65078 0
+      vertex -13.7518 3.5 -17
+      vertex -12.7524 5.5921 -17
+      vertex -12.4488 5.48599 -17
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.472992 5.549 -17
+      vertex -2.57899 3.5 -17
+      vertex -2.57899 5.549 -17
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 30.4944 6.52169 0
-      vertex 32.9 10.0229 0
-      vertex 31.0706 6.18903 0
+      vertex -0.472992 6.37999 -17
+      vertex -2.57899 6.37999 -17
+      vertex -0.472992 8.29999 -17
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 29.8328 6.59123 0
-      vertex 32.9 10.0229 0
-      vertex 30.4944 6.52169 0
+      vertex 1.95552 1.59766 -17
+      vertex -0.472992 3.5 -17
+      vertex 0.532013 3.5 -17
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 27.0711 9 0
-      vertex 29.8328 6.59123 0
-      vertex 29.2 6.38564 0
+      vertex -0.472992 3.5 -17
+      vertex -2.57899 3.5 -17
+      vertex -0.472992 5.549 -17
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 27.0711 9 0
-      vertex 29.2 6.38564 0
-      vertex 28.7056 5.94046 0
+      vertex 1.95552 1.59766 -17
+      vertex -2.57899 3.5 -17
+      vertex -0.472992 3.5 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.95552 1.59766 -17
+      vertex -3.584 3.5 -17
+      vertex -2.57899 3.5 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.584 3.5 -17
+      vertex -4.08591 3.5 -17
+      vertex -3.584 8.29999 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.95552 1.59766 -17
+      vertex -4.08591 3.5 -17
+      vertex -3.584 3.5 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.95552 1.59766 -17
+      vertex -5.09091 3.5 -17
+      vertex -4.08591 3.5 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.09091 3.5 -17
+      vertex -7.15892 4.728 -17
+      vertex -5.48091 4.728 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.09091 3.5 -17
+      vertex -7.54991 3.5 -17
+      vertex -7.15892 4.728 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.95552 1.59766 -17
+      vertex -7.54991 3.5 -17
+      vertex -5.09091 3.5 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.95552 1.59766 -17
+      vertex -8.54492 3.5 -17
+      vertex -7.54991 3.5 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.95552 1.59766 -17
+      vertex -9.30783 3.5 -17
+      vertex -8.54492 3.5 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.95552 1.59766 -17
+      vertex -10.3128 3.5 -17
+      vertex -9.30783 3.5 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.3128 3.5 -17
+      vertex -11.5018 5.29199 -17
+      vertex -10.3128 5.29199 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.3128 3.5 -17
+      vertex -12.6208 3.5 -17
+      vertex -11.5018 5.29199 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.95552 1.59766 -17
+      vertex -12.6208 3.5 -17
+      vertex -10.3128 3.5 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.95552 1.59766 -17
+      vertex -13.7518 3.5 -17
+      vertex -12.6208 3.5 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.95552 1.59766 -17
+      vertex -14.2218 3.5 -17
+      vertex -13.7518 3.5 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.95552 1.59766 -17
+      vertex -15.2268 3.5 -17
+      vertex -14.2218 3.5 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -15.2268 3.5 -17
+      vertex -16.1203 3.5 -17
+      vertex -15.2268 8.29999 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -29.676 1.91698 -17
+      vertex -15.2268 3.5 -17
+      vertex 1.95552 1.59766 -17
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -15.2268 3.5 -17
+      vertex -29.676 1.91698 -17
+      vertex -16.1203 3.5 -17
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -16.1203 3.5 -17
+      vertex -29.676 1.91698 -17
+      vertex -18.5303 3.5 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.145 4.59776 -17
+      vertex -20.3903 4.877 -17
+      vertex -20.3356 4.47198 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.3903 4.877 -17
+      vertex -20.9307 5.20444 -17
+      vertex -20.8593 5.92 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.145 4.59776 -17
+      vertex -20.3356 4.47198 -17
+      vertex -20.1712 4.133 -17
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -20.3903 4.877 -17
+      vertex -21.145 4.59776 -17
+      vertex -20.9307 5.20444 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.5023 4.09999 -17
+      vertex -20.1712 4.133 -17
+      vertex -19.8973 3.85999 -17
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -20.1712 4.133 -17
+      vertex -21.5023 4.09999 -17
+      vertex -21.145 4.59776 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.986 3.73111 -17
+      vertex -19.8973 3.85999 -17
+      vertex -19.5268 3.65999 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.5787 3.50977 -17
+      vertex -19.5268 3.65999 -17
+      vertex -19.0711 3.53999 -17
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -19.8973 3.85999 -17
+      vertex -21.986 3.73111 -17
+      vertex -21.5023 4.09999 -17
     endloop
   endfacet
   facet normal 0 -0 -1
     outer loop
-      vertex 27.1 10.0229 0
-      vertex 29.8328 6.59123 0
-      vertex 27.0711 9 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 27.0711 9 0
-      vertex 28.7056 5.94046 0
-      vertex 28.435 5.33266 0
+      vertex -28.45 2.31532 -17
+      vertex -18.5303 3.5 -17
+      vertex -29.676 1.91698 -17
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 28.7056 4.05954 0
-      vertex 27.0711 0 0
-      vertex 28.435 4.66734 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 27.0711 9 0
-      vertex 28.435 4.66734 0
-      vertex 27.0711 0 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 29.8328 6.59123 0
-      vertex 27.1 10.0229 0
-      vertex 32.9 10.0229 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 28.435 4.66734 0
-      vertex 27.0711 9 0
-      vertex 28.435 5.33266 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 27.1 10.0229 0
-      vertex 27.0711 9 0
-      vertex 27.0868 10 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 21 10 0
-      vertex 27.0711 9 0
-      vertex 21 9 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 27.0711 9 0
-      vertex 21 10 0
-      vertex 27.0868 10 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 0.5 5 0
-      vertex 1 10 0
-      vertex 1 5 0
+      vertex -19.5268 3.65999 -17
+      vertex -22.5787 3.50977 -17
+      vertex -21.986 3.73111 -17
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 1 10 0
-      vertex 0.5 5 0
-      vertex 0.5 10 0
+      vertex -18.5303 3.5 -17
+      vertex -28.45 2.31532 -17
+      vertex -19.0711 3.53999 -17
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -23.2803 3.436 -17
+      vertex -19.0711 3.53999 -17
+      vertex -28.45 2.31532 -17
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 1 2.14213 0
-      vertex -3 2.64214 0
-      vertex -0.5 5 0
+      vertex -25.5863 5.00356 -17
+      vertex -26.9677 5.64453 -17
+      vertex -25.6853 5.44188 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.9677 5.64453 -17
+      vertex -25.5863 5.00356 -17
+      vertex -26.9677 4.35547 -17
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex -0.5 5 0
-      vertex -3 2.64214 0
-      vertex -3 5 0
+      vertex -25.4213 4.605 -17
+      vertex -26.9677 4.35547 -17
+      vertex -25.5863 5.00356 -17
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -0.357864 0 0
-      vertex 2 1.14214 0
-      vertex 2 0 0
+      vertex -25.1948 4.25655 -17
+      vertex -26.9677 4.35547 -17
+      vertex -25.4213 4.605 -17
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 1 2.14213 0
-      vertex 0.5 5 0
-      vertex 1 5 0
+      vertex -27.492 3.17787 -17
+      vertex -25.1948 4.25655 -17
+      vertex -24.9115 3.96721 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.492 3.17787 -17
+      vertex -24.9115 3.96721 -17
+      vertex -24.5713 3.737 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.492 3.17787 -17
+      vertex -24.5713 3.737 -17
+      vertex -24.182 3.56976 -17
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 2 1.14214 0
-      vertex -0.357864 0 0
-      vertex 1 2.14213 0
+      vertex -25.1948 4.25655 -17
+      vertex -27.492 3.17787 -17
+      vertex -26.9677 4.35547 -17
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex -3 2.64214 0
-      vertex 1 2.14213 0
-      vertex -0.357864 0 0
+      vertex -28.45 2.31532 -17
+      vertex -24.182 3.56976 -17
+      vertex -23.7517 3.46945 -17
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 1 2.14213 0
-      vertex -0.5 5 0
-      vertex 0.5 5 0
+      vertex -19.0711 3.53999 -17
+      vertex -23.2803 3.436 -17
+      vertex -22.5787 3.50977 -17
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 0.5 5 0
-      vertex -0.5 5 0
-      vertex 0.5 10 0
+      vertex -24.182 3.56976 -17
+      vertex -28.45 2.31532 -17
+      vertex -27.492 3.17787 -17
     endloop
   endfacet
   facet normal -0 0 -1
     outer loop
-      vertex 0.5 10 0
-      vertex -0.5 5 0
-      vertex -0.5 10 0
+      vertex -23.2803 3.436 -17
+      vertex -28.45 2.31532 -17
+      vertex -23.7517 3.46945 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -35.2506 4.98453 -17
+      vertex -32.832 3.73912 -17
+      vertex -33.2952 1.59766 -17
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -32.0743 2.69625 -17
+      vertex -33.2952 1.59766 -17
+      vertex -32.832 3.73912 -17
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -30.958 2.05172 -17
+      vertex -33.2952 1.59766 -17
+      vertex -32.0743 2.69625 -17
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -29.676 1.91698 -17
+      vertex -33.2952 1.59766 -17
+      vertex -30.958 2.05172 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -33.2952 1.59766 -17
+      vertex -29.676 1.91698 -17
+      vertex 1.95552 1.59766 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.532013 3.5 -17
+      vertex 2 1.64214 -17
+      vertex 1.95552 1.59766 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 2 1.64214 -17
+      vertex 0.532013 3.5 -17
+      vertex 2 10 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.532013 8.29999 -17
+      vertex 2 10 -17
+      vertex 0.532013 3.5 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.472992 8.29999 -17
+      vertex 2 10 -17
+      vertex 0.532013 8.29999 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.57899 8.29999 -17
+      vertex -0.472992 8.29999 -17
+      vertex -2.57899 6.37999 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.57899 8.29999 -17
+      vertex 2 10 -17
+      vertex -0.472992 8.29999 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.584 8.29999 -17
+      vertex 2 10 -17
+      vertex -2.57899 8.29999 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.72592 8.29999 -17
+      vertex -3.584 8.29999 -17
+      vertex -4.08591 3.5 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.72592 8.29999 -17
+      vertex 2 10 -17
+      vertex -3.584 8.29999 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.91092 8.29999 -17
+      vertex 2 10 -17
+      vertex -5.72592 8.29999 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.30783 8.29999 -17
+      vertex -8.54492 3.5 -17
+      vertex -9.30783 3.5 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.54492 3.5 -17
+      vertex -9.30783 8.29999 -17
+      vertex -6.91092 8.29999 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.30783 8.29999 -17
+      vertex 2 10 -17
+      vertex -6.91092 8.29999 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.7148 8.29999 -17
+      vertex 2 10 -17
+      vertex -9.30783 8.29999 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.2218 8.29999 -17
+      vertex -11.7148 8.29999 -17
+      vertex -12.2452 8.25844 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.2218 8.29999 -17
+      vertex -13.4808 6.52899 -17
+      vertex -14.2218 3.5 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.4808 6.52899 -17
+      vertex -14.2218 8.29999 -17
+      vertex -13.5128 6.853 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -13.5128 6.853 -17
+      vertex -14.2218 8.29999 -17
+      vertex -13.4607 7.28333 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.2218 8.29999 -17
+      vertex -13.3044 7.64099 -17
+      vertex -13.4607 7.28333 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.2218 8.29999 -17
+      vertex -13.0438 7.92599 -17
+      vertex -13.3044 7.64099 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.2218 8.29999 -17
+      vertex -12.6882 8.13377 -17
+      vertex -13.0438 7.92599 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.2218 8.29999 -17
+      vertex -12.2452 8.25844 -17
+      vertex -12.6882 8.13377 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.7148 8.29999 -17
+      vertex -14.2218 8.29999 -17
+      vertex 2 10 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.0868 10 -17
+      vertex -14.2218 8.29999 -17
+      vertex -15.2268 8.29999 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -16.1203 8.29999 -17
+      vertex -15.2268 8.29999 -17
+      vertex -16.1203 3.5 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.0868 10 -17
+      vertex -15.2268 8.29999 -17
+      vertex -16.1203 8.29999 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.0868 10 -17
+      vertex -16.1203 8.29999 -17
+      vertex -18.3253 8.29999 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.0868 10 -17
+      vertex -18.3253 8.29999 -17
+      vertex -18.8657 8.26633 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.8593 5.92 -17
+      vertex -20.2539 5.44899 -17
+      vertex -20.3562 5.18466 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.8593 5.92 -17
+      vertex -20.3562 5.18466 -17
+      vertex -20.3903 4.877 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.012 6.61665 -17
+      vertex -20.9306 6.63222 -17
+      vertex -20.088 6.84532 -17
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -20.088 6.84532 -17
+      vertex -20.9306 6.63222 -17
+      vertex -20.1133 7.10199 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.1446 7.23155 -17
+      vertex -20.1133 7.10199 -17
+      vertex -20.9306 6.63222 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.1133 7.10199 -17
+      vertex -21.1446 7.23155 -17
+      vertex -20.063 7.46455 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.5013 7.71799 -17
+      vertex -20.063 7.46455 -17
+      vertex -21.1446 7.23155 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.063 7.46455 -17
+      vertex -21.5013 7.71799 -17
+      vertex -19.912 7.76288 -17
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -19.912 7.76288 -17
+      vertex -21.5013 7.71799 -17
+      vertex -19.6603 7.99699 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.985 8.07687 -17
+      vertex -19.6603 7.99699 -17
+      vertex -21.5013 7.71799 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.6603 7.99699 -17
+      vertex -21.985 8.07687 -17
+      vertex -19.3107 8.16533 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.5804 8.29222 -17
+      vertex -19.3107 8.16533 -17
+      vertex -21.985 8.07687 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.3107 8.16533 -17
+      vertex -22.5804 8.29222 -17
+      vertex -18.8657 8.26633 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.0868 10 -17
+      vertex -18.8657 8.26633 -17
+      vertex -22.5804 8.29222 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.0868 10 -17
+      vertex -22.5804 8.29222 -17
+      vertex -23.2873 8.364 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.6853 5.44188 -17
+      vertex -26.9677 5.64453 -17
+      vertex -25.7183 5.92 -17
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -25.7183 5.92 -17
+      vertex -26.9677 5.64453 -17
+      vertex -25.6467 6.62521 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.492 6.82213 -17
+      vertex -25.6467 6.62521 -17
+      vertex -26.9677 5.64453 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.6467 6.62521 -17
+      vertex -27.492 6.82213 -17
+      vertex -25.432 7.22221 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -14.2218 8.29999 -17
+      vertex -27.0868 10 -17
+      vertex 2 10 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.9943 8.29144 -17
+      vertex -27.0868 10 -17
+      vertex -23.2873 8.364 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.5899 8.07378 -17
+      vertex -27.0868 10 -17
+      vertex -23.9943 8.29144 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.0743 7.711 -17
+      vertex -27.0868 10 -17
+      vertex -24.5899 8.07378 -17
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -27.0868 10 -17
+      vertex -25.432 7.22221 -17
+      vertex -27.492 6.82213 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.432 7.22221 -17
+      vertex -27.0868 10 -17
+      vertex -25.0743 7.711 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.45 7.68468 -17
+      vertex -27.0868 10 -17
+      vertex -27.492 6.82213 -17
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.0868 10 -17
+      vertex -28.45 7.68468 -17
+      vertex -27.1 10.0229 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -29.676 8.08302 -17
+      vertex -27.1 10.0229 -17
+      vertex -28.45 7.68468 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -32.3417 10.0229 -17
+      vertex -29.676 8.08302 -17
+      vertex -30.958 7.94827 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -29.676 8.08302 -17
+      vertex -32.3417 10.0229 -17
+      vertex -27.1 10.0229 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -32.0743 7.30375 -17
+      vertex -32.3417 10.0229 -17
+      vertex -30.958 7.94827 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -32.832 6.26088 -17
+      vertex -32.3417 10.0229 -17
+      vertex -32.0743 7.30375 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -35.2506 4.98453 -17
+      vertex -32.832 6.26088 -17
+      vertex -33.1 5 -17
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -32.832 6.26088 -17
+      vertex -35.2506 4.98453 -17
+      vertex -32.3417 10.0229 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -32.832 3.73912 -17
+      vertex -35.2506 4.98453 -17
+      vertex -33.1 5 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.22391 7.20699 -17
+      vertex -6.38391 7.32599 -17
+      vertex -6.31792 7.56099 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.51791 6.86299 -17
+      vertex -6.22391 7.20699 -17
+      vertex -6.14514 6.94577 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.51791 6.86299 -17
+      vertex -6.14514 6.94577 -17
+      vertex -5.68692 5.48399 -17
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -6.22391 7.20699 -17
+      vertex -6.51791 6.86299 -17
+      vertex -6.38391 7.32599 -17
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -6.51791 6.86299 -17
+      vertex -5.68692 5.48399 -17
+      vertex -6.95291 5.48399 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10.3128 6.07199 -17
+      vertex -11.6098 7.51999 -17
+      vertex -10.3128 7.51999 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.6368 6.07199 -17
+      vertex -11.6098 7.51999 -17
+      vertex -10.3128 6.07199 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.8978 6.09366 -17
+      vertex -11.6098 7.51999 -17
+      vertex -11.6368 6.07199 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.8978 6.09366 -17
+      vertex -12.1054 7.44144 -17
+      vertex -11.6098 7.51999 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.5018 6.81299 -17
+      vertex -11.8978 6.09366 -17
+      vertex -12.1128 6.15866 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.4774 6.59633 -17
+      vertex -12.1128 6.15866 -17
+      vertex -12.2818 6.267 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -11.8978 6.09366 -17
+      vertex -12.5018 6.81299 -17
+      vertex -12.1054 7.44144 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.4774 6.59633 -17
+      vertex -12.2818 6.267 -17
+      vertex -12.4041 6.41432 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.1128 6.15866 -17
+      vertex -12.4774 6.59633 -17
+      vertex -12.5018 6.81299 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -12.1054 7.44144 -17
+      vertex -12.5018 6.81299 -17
+      vertex -12.4027 7.20576 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.1253 4.24599 -17
+      vertex -18.4083 5.63699 -17
+      vertex -17.1253 5.63699 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.4463 4.24599 -17
+      vertex -18.4083 5.63699 -17
+      vertex -17.1253 4.24599 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.7418 4.26566 -17
+      vertex -18.4083 5.63699 -17
+      vertex -18.4463 4.24599 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.7418 4.26566 -17
+      vertex -18.9494 5.56122 -17
+      vertex -18.4083 5.63699 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.9788 4.32466 -17
+      vertex -18.9494 5.56122 -17
+      vertex -18.7418 4.26566 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.3573 4.73854 -17
+      vertex -18.9788 4.32466 -17
+      vertex -19.1573 4.42299 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.9788 4.32466 -17
+      vertex -19.3823 4.95499 -17
+      vertex -18.9494 5.56122 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.3573 4.73854 -17
+      vertex -19.1573 4.42299 -17
+      vertex -19.2823 4.56122 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.9788 4.32466 -17
+      vertex -19.3573 4.73854 -17
+      vertex -19.3823 4.95499 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.9494 5.56122 -17
+      vertex -19.3823 4.95499 -17
+      vertex -19.2741 5.33388 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -17.1253 6.37999 -17
+      vertex -18.2783 7.55399 -17
+      vertex -17.1253 7.55399 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.2853 6.37999 -17
+      vertex -18.2783 7.55399 -17
+      vertex -17.1253 6.37999 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.2853 6.37999 -17
+      vertex -18.5286 7.53899 -17
+      vertex -18.2783 7.55399 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.5452 6.39621 -17
+      vertex -18.5286 7.53899 -17
+      vertex -18.2853 6.37999 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.5452 6.39621 -17
+      vertex -18.7339 7.49399 -17
+      vertex -18.5286 7.53899 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.7529 6.44489 -17
+      vertex -18.7339 7.49399 -17
+      vertex -18.5452 6.39621 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.1023 6.965 -17
+      vertex -18.7339 7.49399 -17
+      vertex -18.7529 6.44489 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.0808 6.78644 -17
+      vertex -18.7529 6.44489 -17
+      vertex -18.9083 6.52599 -17
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -19.0792 7.15765 -17
+      vertex -18.7339 7.49399 -17
+      vertex -19.1023 6.965 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -19.0808 6.78644 -17
+      vertex -18.9083 6.52599 -17
+      vertex -19.0161 6.64011 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.7339 7.49399 -17
+      vertex -19.0792 7.15765 -17
+      vertex -18.8943 7.41899 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.7529 6.44489 -17
+      vertex -19.0808 6.78644 -17
+      vertex -19.1023 6.965 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -18.8943 7.41899 -17
+      vertex -19.0792 7.15765 -17
+      vertex -19.0099 7.30899 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.6933 5.92 -17
+      vertex -21.8713 5.92 -17
+      vertex -21.9133 5.43233 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.8713 5.92 -17
+      vertex -24.6933 5.92 -17
+      vertex -21.9123 6.40233 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.6524 5.42032 -17
+      vertex -21.9133 5.43233 -17
+      vertex -22.0393 5.01866 -17
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -24.6521 6.39932 -17
+      vertex -21.9123 6.40233 -17
+      vertex -24.6933 5.92 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.2803 4.226 -17
+      vertex -22.0393 5.01866 -17
+      vertex -22.2493 4.67899 -17
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -23.2873 7.57399 -17
+      vertex -21.9123 6.40233 -17
+      vertex -24.6521 6.39932 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.8755 4.27632 -17
+      vertex -22.2493 4.67899 -17
+      vertex -22.5318 4.42732 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.9123 6.40233 -17
+      vertex -23.2873 7.57399 -17
+      vertex -22.0353 6.808 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.2493 4.67899 -17
+      vertex -22.8755 4.27632 -17
+      vertex -23.2803 4.226 -17
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -22.0393 5.01866 -17
+      vertex -23.2803 4.226 -17
+      vertex -24.6524 5.42032 -17
+    endloop
+  endfacet
+  facet normal -0 -0 -1
+    outer loop
+      vertex -22.87 7.52544 -17
+      vertex -22.0353 6.808 -17
+      vertex -23.2873 7.57399 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.5297 5.00266 -17
+      vertex -23.2803 4.226 -17
+      vertex -23.6977 4.27499 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.2403 7.13699 -17
+      vertex -22.87 7.52544 -17
+      vertex -22.521 7.37978 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.0353 6.808 -17
+      vertex -22.87 7.52544 -17
+      vertex -22.2403 7.13699 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.3253 4.66699 -17
+      vertex -23.6977 4.27499 -17
+      vertex -24.046 4.422 -17
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -24.5288 6.80399 -17
+      vertex -23.2873 7.57399 -17
+      vertex -24.6521 6.39932 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.6977 4.27499 -17
+      vertex -24.3253 4.66699 -17
+      vertex -24.5297 5.00266 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.2873 7.57399 -17
+      vertex -24.5288 6.80399 -17
+      vertex -23.6988 7.5251 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.2803 4.226 -17
+      vertex -24.5297 5.00266 -17
+      vertex -24.6524 5.42032 -17
+    endloop
+  endfacet
+  facet normal 0 -0 -1
+    outer loop
+      vertex -24.3233 7.13399 -17
+      vertex -23.6988 7.5251 -17
+      vertex -24.5288 6.80399 -17
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -21.9133 5.43233 -17
+      vertex -24.6524 5.42032 -17
+      vertex -24.6933 5.92 -17
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.6988 7.5251 -17
+      vertex -24.3233 7.13399 -17
+      vertex -24.0441 7.37843 -17
+    endloop
+  endfacet
+  facet normal -1.22461e-016 0 1
+    outer loop
+      vertex -21 10 -2.57167e-015
+      vertex -27.0711 9 -3.31514e-015
+      vertex -21 9 -2.57167e-015
+    endloop
+  endfacet
+  facet normal -1.22461e-016 -1.92922e-023 1
+    outer loop
+      vertex -27.0868 10 -3.31706e-015
+      vertex -27.0711 9 -3.31514e-015
+      vertex -21 10 -2.57167e-015
+    endloop
+  endfacet
+  facet normal -1.22467e-016 -1.15636e-022 1
+    outer loop
+      vertex -27.1 10.0229 -3.31868e-015
+      vertex -27.0711 9 -3.31514e-015
+      vertex -27.0868 10 -3.31706e-015
+    endloop
+  endfacet
+  facet normal -1.22461e-016 0 1
+    outer loop
+      vertex -28.435 4.66734 -3.48216e-015
+      vertex -27.0711 9 -3.31514e-015
+      vertex -28.435 5.33266 -3.48216e-015
+    endloop
+  endfacet
+  facet normal -1.22461e-016 5.5229e-023 1
+    outer loop
+      vertex -27.0711 9 -3.31514e-015
+      vertex -27.1 10.0229 -3.31868e-015
+      vertex -29.8328 6.59123 -3.65334e-015
+    endloop
+  endfacet
+  facet normal -1.22461e-016 0 1
+    outer loop
+      vertex -27.0711 9 -3.31514e-015
+      vertex -28.435 4.66734 -3.48216e-015
+      vertex -27.0711 0 -3.31514e-015
+    endloop
+  endfacet
+  facet normal -1.22461e-016 2.42659e-023 1
+    outer loop
+      vertex -28.7056 4.05954 -3.5153e-015
+      vertex -27.0711 0 -3.31514e-015
+      vertex -28.435 4.66734 -3.48216e-015
+    endloop
+  endfacet
+  facet normal -1.22461e-016 -2.78711e-023 1
+    outer loop
+      vertex -27.0711 9 -3.31514e-015
+      vertex -28.7056 5.94046 -3.5153e-015
+      vertex -28.435 5.33266 -3.48216e-015
+    endloop
+  endfacet
+  facet normal -1.2246e-016 -1.45313e-022 1
+    outer loop
+      vertex -27.0711 9 -3.31514e-015
+      vertex -29.2 6.38564 -3.57585e-015
+      vertex -28.7056 5.94046 -3.5153e-015
+    endloop
+  endfacet
+  facet normal -1.22461e-016 5.65166e-022 1
+    outer loop
+      vertex -27.0711 9 -3.31514e-015
+      vertex -29.8328 6.59123 -3.65334e-015
+      vertex -29.2 6.38564 -3.57585e-015
+    endloop
+  endfacet
+  facet normal -1.22461e-016 -5.70669e-023 1
+    outer loop
+      vertex -32.9 10.0229 -4.02895e-015
+      vertex -29.8328 6.59123 -3.65334e-015
+      vertex -27.1 10.0229 -3.31868e-015
+    endloop
+  endfacet
+  facet normal -1.2246e-016 4.17629e-022 1
+    outer loop
+      vertex -29.8328 6.59123 -3.65334e-015
+      vertex -32.9 10.0229 -4.02895e-015
+      vertex -30.4944 6.52169 -3.73437e-015
+    endloop
+  endfacet
+  facet normal -1.22461e-016 9.87846e-024 1
+    outer loop
+      vertex -35.8 5 -4.38409e-015
+      vertex -31.4617 5.65078 -3.85282e-015
+      vertex -32.9 10.0229 -4.02895e-015
+    endloop
+  endfacet
+  facet normal -1.22461e-016 -3.11357e-023 1
+    outer loop
+      vertex -31.0706 6.18903 -3.80493e-015
+      vertex -32.9 10.0229 -4.02895e-015
+      vertex -31.4617 5.65078 -3.85282e-015
+    endloop
+  endfacet
+  facet normal -1.22461e-016 2.31619e-023 1
+    outer loop
+      vertex -30.4944 6.52169 -3.73437e-015
+      vertex -32.9 10.0229 -4.02895e-015
+      vertex -31.0706 6.18903 -3.80493e-015
+    endloop
+  endfacet
+  facet normal -1.22459e-016 4.73674e-022 1
+    outer loop
+      vertex -27.0711 0 -3.31514e-015
+      vertex -28.7056 4.05954 -3.5153e-015
+      vertex -27.0868 0 -3.31706e-015
+    endloop
+  endfacet
+  facet normal -1.2246e-016 1.21546e-022 1
+    outer loop
+      vertex -29.2 3.61436 -3.57585e-015
+      vertex -27.0868 0 -3.31706e-015
+      vertex -28.7056 4.05954 -3.5153e-015
+    endloop
+  endfacet
+  facet normal -1.22461e-016 -4.27284e-022 1
+    outer loop
+      vertex -29.8328 3.40876 -3.65334e-015
+      vertex -27.0868 0 -3.31706e-015
+      vertex -29.2 3.61436 -3.57585e-015
+    endloop
+  endfacet
+  facet normal -1.22463e-016 -1.97821e-021 1
+    outer loop
+      vertex -27.0868 0 -3.31706e-015
+      vertex -29.8328 3.40876 -3.65334e-015
+      vertex -27.1 -0.0229473 -3.31868e-015
+    endloop
+  endfacet
+  facet normal -1.2246e-016 -4.17629e-022 1
+    outer loop
+      vertex -32.9 -0.0229473 -4.02895e-015
+      vertex -29.8328 3.40876 -3.65334e-015
+      vertex -30.4944 3.47831 -3.73437e-015
+    endloop
+  endfacet
+  facet normal -1.22461e-016 -2.31619e-023 1
+    outer loop
+      vertex -32.9 -0.0229473 -4.02895e-015
+      vertex -30.4944 3.47831 -3.73437e-015
+      vertex -31.0706 3.81097 -3.80493e-015
+    endloop
+  endfacet
+  facet normal -1.22461e-016 -3.86836e-022 1
+    outer loop
+      vertex -31.4617 5.65078 -3.85282e-015
+      vertex -35.8 5 -4.38409e-015
+      vertex -31.6 5 -3.86976e-015
+    endloop
+  endfacet
+  facet normal -1.22461e-016 5.70669e-023 1
+    outer loop
+      vertex -29.8328 3.40876 -3.65334e-015
+      vertex -32.9 -0.0229473 -4.02895e-015
+      vertex -27.1 -0.0229473 -3.31868e-015
+    endloop
+  endfacet
+  facet normal -1.22461e-016 3.11357e-023 1
+    outer loop
+      vertex -31.4617 4.34922 -3.85282e-015
+      vertex -32.9 -0.0229473 -4.02895e-015
+      vertex -31.0706 3.81097 -3.80493e-015
+    endloop
+  endfacet
+  facet normal -1.22461e-016 3.86835e-022 1
+    outer loop
+      vertex -31.6 5 -3.86976e-015
+      vertex -35.8 5 -4.38409e-015
+      vertex -31.4617 4.34922 -3.85282e-015
+    endloop
+  endfacet
+  facet normal -1.22461e-016 -9.87846e-024 1
+    outer loop
+      vertex -31.4617 4.34922 -3.85282e-015
+      vertex -35.8 5 -4.38409e-015
+      vertex -32.9 -0.0229473 -4.02895e-015
+    endloop
+  endfacet
+  facet normal -1.22461e-016 0 1
+    outer loop
+      vertex -1 10 -1.22461e-016
+      vertex -0.5 5 -6.12303e-017
+      vertex -0.5 10 -6.12303e-017
+    endloop
+  endfacet
+  facet normal -1.22461e-016 0 1
+    outer loop
+      vertex -0.5 5 -6.12303e-017
+      vertex -1 10 -1.22461e-016
+      vertex -1 5 -1.22461e-016
+    endloop
+  endfacet
+  facet normal -1.22461e-016 0 1
+    outer loop
+      vertex -0.5 5 -6.12303e-017
+      vertex 0.5 5 6.12303e-017
+      vertex 0.5 10 6.12303e-017
+    endloop
+  endfacet
+  facet normal -1.22461e-016 0 1
+    outer loop
+      vertex -0.5 5 -6.12303e-017
+      vertex 0.5 10 6.12303e-017
+      vertex -0.5 10 -6.12303e-017
+    endloop
+  endfacet
+  facet normal -1.22461e-016 0 1
+    outer loop
+      vertex -1 2.14213 -1.22461e-016
+      vertex 0.5 5 6.12303e-017
+      vertex -0.5 5 -6.12303e-017
+    endloop
+  endfacet
+  facet normal -1.22461e-016 0 1
+    outer loop
+      vertex -1 2.14213 -1.22461e-016
+      vertex -0.5 5 -6.12303e-017
+      vertex -1 5 -1.22461e-016
+    endloop
+  endfacet
+  facet normal -1.22461e-016 9.42871e-026 1
+    outer loop
+      vertex 0.5 5 6.12303e-017
+      vertex -1 2.14213 -1.22461e-016
+      vertex 0.357864 0 4.38242e-017
+    endloop
+  endfacet
+  facet normal -1.22461e-016 1.27401e-025 1
+    outer loop
+      vertex -2 1.14214 -2.44921e-016
+      vertex 0.357864 0 4.38242e-017
+      vertex -1 2.14213 -1.22461e-016
+    endloop
+  endfacet
+  facet normal -1.22461e-016 0 1
+    outer loop
+      vertex 0.357864 0 4.38242e-017
+      vertex -2 1.14214 -2.44921e-016
+      vertex -2 0 -2.44921e-016
+    endloop
+  endfacet
+  facet normal -1.22461e-016 0 1
+    outer loop
+      vertex 0.5 5 6.12303e-017
+      vertex 3 2.64214 3.67382e-016
+      vertex 3 5 3.67382e-016
+    endloop
+  endfacet
+  facet normal -1.22461e-016 8.68518e-026 1
+    outer loop
+      vertex 3 2.64214 3.67382e-016
+      vertex 0.5 5 6.12303e-017
+      vertex 0.357864 0 4.38242e-017
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
-      vertex 24.5 0 0.5
-      vertex 27.0868 0 12.6105
-      vertex -0.357864 0 12.6105
+      vertex -27.0868 0 -3.31706e-015
+      vertex -25.5355 0 -1.53553
+      vertex -27.0711 0 -3.31514e-015
+    endloop
+  endfacet
+  facet normal -0 -1 0
+    outer loop
+      vertex -25.5355 0 -1.53553
+      vertex -27.0868 0 -3.31706e-015
+      vertex -27.0868 0 -12.6105
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
-      vertex 24.5 0 0.5
-      vertex -0.357864 0 12.6105
-      vertex 2 0 0.5
+      vertex -27.0868 0 -12.6105
+      vertex -24.5 0 -0.5
+      vertex -25.5355 0 -1.53553
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
-      vertex -0.357864 0 0
-      vertex 2 0 0.5
-      vertex -0.357864 0 12.6105
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 2 0 0.5
-      vertex -0.357864 0 0
-      vertex 2 0 0
+      vertex -2 0 -0.5
+      vertex 0.357864 0 4.38242e-017
+      vertex -2 0 -2.44921e-016
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
-      vertex 27.0868 0 0
-      vertex 25.5355 0 1.53553
-      vertex 27.0711 0 0
+      vertex 0.357864 0 -12.6105
+      vertex -24.5 0 -0.5
+      vertex -27.0868 0 -12.6105
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
-      vertex 25.5355 0 1.53553
-      vertex 27.0868 0 0
-      vertex 27.0868 0 12.6105
+      vertex -24.5 0 -0.5
+      vertex 0.357864 0 -12.6105
+      vertex -2 0 -0.5
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
-      vertex 27.0868 0 12.6105
-      vertex 24.5 0 0.5
-      vertex 25.5355 0 1.53553
+      vertex -2 0 -0.5
+      vertex 0.357864 0 -12.6105
+      vertex 0.357864 0 4.38242e-017
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 27.0868 10 17
-      vertex 21 10 15.5
-      vertex -2 10 17
+      vertex 2 10 6
+      vertex 0.5 10 6.12303e-017
+      vertex 0.5 10 6
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -1 10 -15.5
+      vertex -0.5 10 -6.12303e-017
+      vertex 0.5 10 6.12303e-017
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -0.5 10 -6.12303e-017
+      vertex -1 10 -15.5
+      vertex -1 10 -1.22461e-016
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 27.0868 10 0
-      vertex 21 10 15.5
-      vertex 27.0868 10 17
+      vertex 2 10 -17
+      vertex 0.5 10 6.12303e-017
+      vertex 2 10 6
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 21 10 15.5
-      vertex 27.0868 10 0
-      vertex 21 10 0
+      vertex -1 10 -15.5
+      vertex 2 10 -17
+      vertex -21 10 -15.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0.5 10 6.12303e-017
+      vertex 2 10 -17
+      vertex -1 10 -15.5
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 1 10 15.5
-      vertex -2 10 17
-      vertex 21 10 15.5
+      vertex -21 10 -15.5
+      vertex -27.0868 10 -3.31706e-015
+      vertex -21 10 -2.57167e-015
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 0.5 10 0
-      vertex 1 10 15.5
-      vertex 1 10 0
+      vertex -21 10 -15.5
+      vertex -27.0868 10 -17
+      vertex -27.0868 10 -3.31706e-015
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -0.5 10 0
-      vertex 1 10 15.5
-      vertex 0.5 10 0
+      vertex -27.0868 10 -17
+      vertex -21 10 -15.5
+      vertex 2 10 -17
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 -2.0002e-007
+    outer loop
+      vertex -35.8 5 -16.5165
+      vertex -32.9 10.0229 -4.02895e-015
+      vertex -32.9 10.0229 -16.5165
+    endloop
+  endfacet
+  facet normal -0.866026 0.5 0
+    outer loop
+      vertex -32.9 10.0229 -4.02895e-015
+      vertex -35.8 5 -16.5165
+      vertex -35.8 5 -4.38409e-015
+    endloop
+  endfacet
+  facet normal 0.866029 0.499995 0
+    outer loop
+      vertex -27.0868 10 -3.31706e-015
+      vertex -27.1 10.0229 -17
+      vertex -27.1 10.0229 -3.31868e-015
+    endloop
+  endfacet
+  facet normal 0.866029 0.499995 0
+    outer loop
+      vertex -27.1 10.0229 -17
+      vertex -27.0868 10 -3.31706e-015
+      vertex -27.0868 10 -17
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 1 10 15.5
-      vertex -0.5 10 0
-      vertex -2 10 17
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -2 10 -6
-      vertex -0.5 10 0
-      vertex -0.5 10 -6
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex -0.5 10 0
-      vertex -2 10 -6
-      vertex -2 10 17
-    endloop
-  endfacet
-  facet normal 0.866026 0.5 0
-    outer loop
-      vertex 35.8 5 16.5165
-      vertex 32.9 10.0229 0
-      vertex 32.9 10.0229 16.5165
-    endloop
-  endfacet
-  facet normal 0.866026 0.5 0
-    outer loop
-      vertex 32.9 10.0229 0
-      vertex 35.8 5 16.5165
-      vertex 35.8 5 0
-    endloop
-  endfacet
-  facet normal -0.866029 0.499995 0
-    outer loop
-      vertex 27.0868 10 0
-      vertex 27.1 10.0229 17
-      vertex 27.1 10.0229 0
-    endloop
-  endfacet
-  facet normal -0.866029 0.499995 0
-    outer loop
-      vertex 27.1 10.0229 17
-      vertex 27.0868 10 0
-      vertex 27.0868 10 17
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 32.9 10.0229 16.5165
-      vertex 27.1 10.0229 17
-      vertex 32.3417 10.0229 17
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 27.1 10.0229 0
-      vertex 32.9 10.0229 16.5165
-      vertex 32.9 10.0229 0
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 32.9 10.0229 16.5165
-      vertex 27.1 10.0229 0
-      vertex 27.1 10.0229 17
-    endloop
-  endfacet
-  facet normal 0.866026 -0.499999 5.99844e-005
-    outer loop
-      vertex 33.7373 1.4273 16.5319
-      vertex 35.8 5 16.5165
-      vertex 35.7911 4.98453 16.5319
-    endloop
-  endfacet
-  facet normal 0.866026 -0.5 -2.98306e-008
-    outer loop
-      vertex 35.8 5 16.5165
-      vertex 33.7373 1.4273 16.5319
-      vertex 32.9 -0.0229473 12.5474
-    endloop
-  endfacet
-  facet normal 0.866026 -0.5 0
-    outer loop
-      vertex 35.8 5 16.5165
-      vertex 32.9 -0.0229473 12.5474
-      vertex 35.8 5 0
-    endloop
-  endfacet
-  facet normal 0.866026 -0.5 0
-    outer loop
-      vertex 35.8 5 0
-      vertex 32.9 -0.0229473 12.5474
-      vertex 32.9 -0.0229473 0
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 27.1 -0.0229473 0
-      vertex 32.9 -0.0229473 12.5474
-      vertex 27.1 -0.0229473 12.5474
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 32.9 -0.0229473 12.5474
-      vertex 27.1 -0.0229473 0
-      vertex 32.9 -0.0229473 0
-    endloop
-  endfacet
-  facet normal -0.866029 -0.499995 -0
-    outer loop
-      vertex 27.1 -0.0229473 12.5474
-      vertex 27.0868 0 0
-      vertex 27.1 -0.0229473 0
-    endloop
-  endfacet
-  facet normal -0.866029 -0.499995 0
-    outer loop
-      vertex 27.0868 0 0
-      vertex 27.1 -0.0229473 12.5474
-      vertex 27.0868 0 12.6105
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex -3 5 -4.92893
-      vertex -3 9 -6
-      vertex -3 6.07107 -6
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex -3 9 -6
-      vertex -3 5 -4.92893
-      vertex -3 5 0
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex -3 9 -6
-      vertex -3 5 0
-      vertex -3 9 16
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex -3 2.64214 16
-      vertex -3 5 0
-      vertex -3 2.64214 0
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex -3 5 0
-      vertex -3 2.64214 16
-      vertex -3 9 16
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -3 9 -6
-      vertex -0.5 10 -6
-      vertex -0.5 6.07107 -6
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex -3 9 -6
-      vertex -0.5 6.07107 -6
-      vertex -3 6.07107 -6
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex -0.5 10 -6
-      vertex -3 9 -6
-      vertex -2 10 -6
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex 1 2.14213 12.1421
-      vertex 1 10 15.5
-      vertex 1 5.5 15.5
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex 1 10 15.5
-      vertex 1 2.14213 12.1421
-      vertex 1 10 0
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex 1 10 0
-      vertex 1 2.14213 12.1421
-      vertex 1 5 0
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex 1 5 0
-      vertex 1 2.14213 12.1421
-      vertex 1 2.14213 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.8246 5.5 15.5
-      vertex 1 5.5 15.5
-      vertex 13.5 7.79423 15.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 21.3737 5.5 15.5
-      vertex 21 9 15.5
-      vertex 21.3737 9 15.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 15.9793 5.5 15.5
-      vertex 21 9 15.5
-      vertex 21.3737 5.5 15.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.366 8.29423 15.5
-      vertex 21 9 15.5
-      vertex 15.9793 5.5 15.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 21 9 15.5
-      vertex 14.366 8.29423 15.5
-      vertex 21 10 15.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 1 10 15.5
-      vertex 13.5 7.79423 15.5
-      vertex 1 5.5 15.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 13.5 7.79423 15.5
-      vertex 1 10 15.5
-      vertex 14.366 8.29423 15.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 14.366 8.29423 15.5
-      vertex 1 10 15.5
-      vertex 21 10 15.5
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex 26 1 11
-      vertex 26 9 13.8162
-      vertex 26 9 1.07107
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex 26 1 11
-      vertex 26 9 1.07107
-      vertex 26 1 1.07107
-    endloop
-  endfacet
-  facet normal -1 -0 0
-    outer loop
-      vertex 26 9 13.8162
-      vertex 26 1 11
-      vertex 26 3.81618 13.8162
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 21 9 15.5
-      vertex 26 9 13.8162
-      vertex 21.3737 9 15.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 21 9 0
-      vertex 26 9 13.8162
-      vertex 21 9 15.5
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 26 9 13.8162
-      vertex 21 9 0
-      vertex 26 9 1.07107
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 26 9 1.07107
-      vertex 21 9 0
-      vertex 27.0711 9 0
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 26 1 11
-      vertex 18.5773 1 7
-      vertex 18.5773 1 11
+      vertex -27.1 10.0229 -3.31868e-015
+      vertex -32.9 10.0229 -16.5165
+      vertex -32.9 10.0229 -4.02895e-015
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 24.5 1 0.5
-      vertex 18.5773 1 7
-      vertex 25.5355 1 1.53553
+      vertex -27.1 10.0229 -17
+      vertex -32.9 10.0229 -16.5165
+      vertex -27.1 10.0229 -3.31868e-015
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 26 1 11
-      vertex 25.5355 1 1.53553
-      vertex 18.5773 1 7
+      vertex -32.9 10.0229 -16.5165
+      vertex -27.1 10.0229 -17
+      vertex -32.3417 10.0229 -17
     endloop
   endfacet
-  facet normal -0 1 0
+  facet normal 0.866029 -0.499995 0
     outer loop
-      vertex 25.5355 1 1.53553
-      vertex 26 1 11
-      vertex 26 1 1.07107
+      vertex -27.1 -0.0229473 -12.5474
+      vertex -27.0868 0 -3.31706e-015
+      vertex -27.1 -0.0229473 -3.31868e-015
     endloop
   endfacet
-  facet normal 0 1 -0
+  facet normal 0.866029 -0.499995 0
     outer loop
-      vertex 17.4226 1 7
-      vertex 2.14214 1 11
-      vertex 17.4226 1 11
+      vertex -27.0868 0 -3.31706e-015
+      vertex -27.1 -0.0229473 -12.5474
+      vertex -27.0868 0 -12.6105
     endloop
   endfacet
-  facet normal 0 1 0
+  facet normal 0 -1 0
     outer loop
-      vertex 18.5773 1 7
-      vertex 24.5 1 0.5
-      vertex 17.4226 1 7
+      vertex -32.9 -0.0229473 -12.5474
+      vertex -27.1 -0.0229473 -3.31868e-015
+      vertex -32.9 -0.0229473 -4.02895e-015
     endloop
   endfacet
-  facet normal 0 1 0
+  facet normal 0 -1 -0
     outer loop
-      vertex 2.14214 1 0.5
-      vertex 17.4226 1 7
-      vertex 24.5 1 0.5
+      vertex -27.1 -0.0229473 -3.31868e-015
+      vertex -32.9 -0.0229473 -12.5474
+      vertex -27.1 -0.0229473 -12.5474
     endloop
   endfacet
-  facet normal 0 1 0
+  facet normal -0.866026 -0.499999 -5.99844e-005
     outer loop
-      vertex 17.4226 1 7
-      vertex 2.14214 1 0.5
-      vertex 2.14214 1 11
+      vertex -33.7373 1.4273 -16.5319
+      vertex -35.8 5 -16.5165
+      vertex -35.7911 4.98453 -16.5319
     endloop
   endfacet
-  facet normal 0 0.707107 -0.707107
+  facet normal -0.866026 -0.5 8.57641e-007
     outer loop
-      vertex 2.14214 1 11
-      vertex 1 5.5 15.5
-      vertex 14.8246 5.5 15.5
-    endloop
-  endfacet
-  facet normal 0 0.707107 -0.707107
-    outer loop
-      vertex 2.14214 1 11
-      vertex 14.8246 5.5 15.5
-      vertex 17.4226 1 11
-    endloop
-  endfacet
-  facet normal 1.97814e-007 0.707107 -0.707107
-    outer loop
-      vertex 1 5.5 15.5
-      vertex 2.14214 1 11
-      vertex 1 2.14213 12.1421
-    endloop
-  endfacet
-  facet normal 5.82301e-008 0.707107 -0.707107
-    outer loop
-      vertex 26 1 11
-      vertex 21.3737 5.5 15.5
-      vertex 26 3.81618 13.8162
-    endloop
-  endfacet
-  facet normal 0 0.707107 -0.707107
-    outer loop
-      vertex 21.3737 5.5 15.5
-      vertex 26 1 11
-      vertex 18.5773 1 11
-    endloop
-  endfacet
-  facet normal 0 0.707107 -0.707107
-    outer loop
-      vertex 21.3737 5.5 15.5
-      vertex 18.5773 1 11
-      vertex 15.9793 5.5 15.5
-    endloop
-  endfacet
-  facet normal 0.707107 0.707107 0
-    outer loop
-      vertex 2 1.14214 0.5
-      vertex 2.14214 1 11
-      vertex 2.14214 1 0.5
-    endloop
-  endfacet
-  facet normal 0.707107 0.707107 2.29767e-009
-    outer loop
-      vertex 1 2.14213 0
-      vertex 2.14214 1 11
-      vertex 2 1.14214 0.5
-    endloop
-  endfacet
-  facet normal 0.707107 0.707107 0
-    outer loop
-      vertex 1 2.14213 0
-      vertex 2 1.14214 0.5
-      vertex 2 1.14214 0
-    endloop
-  endfacet
-  facet normal 0.707107 0.707107 0
-    outer loop
-      vertex 2.14214 1 11
-      vertex 1 2.14213 0
-      vertex 1 2.14213 12.1421
-    endloop
-  endfacet
-  facet normal -0.34202 0 -0.939693
-    outer loop
-      vertex 21.3737 5.5 15.5
-      vertex 26 9 13.8162
-      vertex 26 3.81618 13.8162
-    endloop
-  endfacet
-  facet normal -0.34202 0 -0.939693
-    outer loop
-      vertex 26 9 13.8162
-      vertex 21.3737 5.5 15.5
-      vertex 21.3737 9 15.5
-    endloop
-  endfacet
-  facet normal -0.978148 -0.207911 0
-    outer loop
-      vertex 31.6 5 0
-      vertex 31.4617 5.65078 13.5
-      vertex 31.4617 5.65078 0
-    endloop
-  endfacet
-  facet normal -0.978148 -0.207911 0
-    outer loop
-      vertex 31.4617 5.65078 13.5
-      vertex 31.6 5 0
-      vertex 31.6 5 13.5
-    endloop
-  endfacet
-  facet normal 1 -0 0
-    outer loop
-      vertex 28.435 4.66734 13.5
-      vertex 28.435 5.33266 0
-      vertex 28.435 5.33266 13.5
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex 28.435 5.33266 0
-      vertex 28.435 4.66734 13.5
-      vertex 28.435 4.66734 0
-    endloop
-  endfacet
-  facet normal -0.104527 -0.994522 0
-    outer loop
-      vertex 29.8328 6.59123 0
-      vertex 30.4944 6.52169 13.5
-      vertex 29.8328 6.59123 13.5
-    endloop
-  endfacet
-  facet normal -0.104527 -0.994522 -0
-    outer loop
-      vertex 30.4944 6.52169 13.5
-      vertex 29.8328 6.59123 0
-      vertex 30.4944 6.52169 0
-    endloop
-  endfacet
-  facet normal 0.669129 -0.743146 0
-    outer loop
-      vertex 28.7056 5.94046 0
-      vertex 29.2 6.38564 13.5
-      vertex 28.7056 5.94046 13.5
-    endloop
-  endfacet
-  facet normal 0.669129 -0.743146 0
-    outer loop
-      vertex 29.2 6.38564 13.5
-      vertex 28.7056 5.94046 0
-      vertex 29.2 6.38564 0
-    endloop
-  endfacet
-  facet normal -0.5 0.866025 0
-    outer loop
-      vertex 31.0706 3.81097 0
-      vertex 30.4944 3.47831 13.5
-      vertex 31.0706 3.81097 13.5
-    endloop
-  endfacet
-  facet normal -0.5 0.866025 0
-    outer loop
-      vertex 30.4944 3.47831 13.5
-      vertex 31.0706 3.81097 0
-      vertex 30.4944 3.47831 0
-    endloop
-  endfacet
-  facet normal -0.104527 0.994522 0
-    outer loop
-      vertex 30.4944 3.47831 0
-      vertex 29.8328 3.40876 13.5
-      vertex 30.4944 3.47831 13.5
-    endloop
-  endfacet
-  facet normal -0.104527 0.994522 0
-    outer loop
-      vertex 29.8328 3.40876 13.5
-      vertex 30.4944 3.47831 0
-      vertex 29.8328 3.40876 0
-    endloop
-  endfacet
-  facet normal -0.5 -0.866025 0
-    outer loop
-      vertex 30.4944 6.52169 0
-      vertex 31.0706 6.18903 13.5
-      vertex 30.4944 6.52169 13.5
-    endloop
-  endfacet
-  facet normal -0.5 -0.866025 -0
-    outer loop
-      vertex 31.0706 6.18903 13.5
-      vertex 30.4944 6.52169 0
-      vertex 31.0706 6.18903 0
-    endloop
-  endfacet
-  facet normal -0.809017 -0.587785 0
-    outer loop
-      vertex 31.4617 5.65078 0
-      vertex 31.0706 6.18903 13.5
-      vertex 31.0706 6.18903 0
-    endloop
-  endfacet
-  facet normal -0.809017 -0.587785 0
-    outer loop
-      vertex 31.0706 6.18903 13.5
-      vertex 31.4617 5.65078 0
-      vertex 31.4617 5.65078 13.5
-    endloop
-  endfacet
-  facet normal 0.309017 -0.951057 0
-    outer loop
-      vertex 29.2 6.38564 0
-      vertex 29.8328 6.59123 13.5
-      vertex 29.2 6.38564 13.5
-    endloop
-  endfacet
-  facet normal 0.309017 -0.951057 0
-    outer loop
-      vertex 29.8328 6.59123 13.5
-      vertex 29.2 6.38564 0
-      vertex 29.8328 6.59123 0
-    endloop
-  endfacet
-  facet normal 0.913546 -0.406736 0
-    outer loop
-      vertex 28.435 5.33266 13.5
-      vertex 28.7056 5.94046 0
-      vertex 28.7056 5.94046 13.5
-    endloop
-  endfacet
-  facet normal 0.913546 -0.406736 0
-    outer loop
-      vertex 28.7056 5.94046 0
-      vertex 28.435 5.33266 13.5
-      vertex 28.435 5.33266 0
-    endloop
-  endfacet
-  facet normal 0.913546 0.406736 0
-    outer loop
-      vertex 28.7056 4.05954 13.5
-      vertex 28.435 4.66734 0
-      vertex 28.435 4.66734 13.5
-    endloop
-  endfacet
-  facet normal 0.913546 0.406736 0
-    outer loop
-      vertex 28.435 4.66734 0
-      vertex 28.7056 4.05954 13.5
-      vertex 28.7056 4.05954 0
-    endloop
-  endfacet
-  facet normal 0.309017 0.951057 -0
-    outer loop
-      vertex 29.8328 3.40876 0
-      vertex 29.2 3.61436 13.5
-      vertex 29.8328 3.40876 13.5
-    endloop
-  endfacet
-  facet normal 0.309017 0.951057 0
-    outer loop
-      vertex 29.2 3.61436 13.5
-      vertex 29.8328 3.40876 0
-      vertex 29.2 3.61436 0
-    endloop
-  endfacet
-  facet normal 0.669129 0.743146 -0
-    outer loop
-      vertex 29.2 3.61436 0
-      vertex 28.7056 4.05954 13.5
-      vertex 29.2 3.61436 13.5
-    endloop
-  endfacet
-  facet normal 0.669129 0.743146 0
-    outer loop
-      vertex 28.7056 4.05954 13.5
-      vertex 29.2 3.61436 0
-      vertex 28.7056 4.05954 0
-    endloop
-  endfacet
-  facet normal -0.809017 0.587785 0
-    outer loop
-      vertex 31.0706 3.81097 0
-      vertex 31.4617 4.34922 13.5
-      vertex 31.4617 4.34922 0
-    endloop
-  endfacet
-  facet normal -0.809017 0.587785 0
-    outer loop
-      vertex 31.4617 4.34922 13.5
-      vertex 31.0706 3.81097 0
-      vertex 31.0706 3.81097 13.5
-    endloop
-  endfacet
-  facet normal -0.978148 0.207911 0
-    outer loop
-      vertex 31.4617 4.34922 0
-      vertex 31.6 5 13.5
-      vertex 31.6 5 0
-    endloop
-  endfacet
-  facet normal -0.978148 0.207911 0
-    outer loop
-      vertex 31.6 5 13.5
-      vertex 31.4617 4.34922 0
-      vertex 31.4617 4.34922 13.5
-    endloop
-  endfacet
-  facet normal -0.978148 -0.207912 0
-    outer loop
-      vertex 33.1 5 13.5
-      vertex 32.832 6.26088 17
-      vertex 32.832 6.26088 13.5
-    endloop
-  endfacet
-  facet normal -0.978148 -0.207912 0
-    outer loop
-      vertex 32.832 6.26088 17
-      vertex 33.1 5 13.5
-      vertex 33.1 5 17
-    endloop
-  endfacet
-  facet normal 1 -0 0
-    outer loop
-      vertex 26.9677 4.35547 17
-      vertex 26.9677 5.64453 13.5
-      vertex 26.9677 5.64453 17
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex 26.9677 5.64453 13.5
-      vertex 26.9677 4.35547 17
-      vertex 26.9677 4.35547 13.5
-    endloop
-  endfacet
-  facet normal -0.104528 -0.994522 0
-    outer loop
-      vertex 29.676 8.08302 13.5
-      vertex 30.958 7.94827 17
-      vertex 29.676 8.08302 17
-    endloop
-  endfacet
-  facet normal -0.104528 -0.994522 -0
-    outer loop
-      vertex 30.958 7.94827 17
-      vertex 29.676 8.08302 13.5
-      vertex 30.958 7.94827 13.5
-    endloop
-  endfacet
-  facet normal -0.500001 -0.866025 0
-    outer loop
-      vertex 30.958 7.94827 13.5
-      vertex 32.0743 7.30375 17
-      vertex 30.958 7.94827 17
-    endloop
-  endfacet
-  facet normal -0.500001 -0.866025 -0
-    outer loop
-      vertex 32.0743 7.30375 17
-      vertex 30.958 7.94827 13.5
-      vertex 32.0743 7.30375 13.5
-    endloop
-  endfacet
-  facet normal -0.809017 -0.587786 0
-    outer loop
-      vertex 32.832 6.26088 13.5
-      vertex 32.0743 7.30375 17
-      vertex 32.0743 7.30375 13.5
-    endloop
-  endfacet
-  facet normal -0.809017 -0.587786 0
-    outer loop
-      vertex 32.0743 7.30375 17
-      vertex 32.832 6.26088 13.5
-      vertex 32.832 6.26088 17
-    endloop
-  endfacet
-  facet normal 0.309018 -0.951056 0
-    outer loop
-      vertex 28.45 7.68468 13.5
-      vertex 29.676 8.08302 17
-      vertex 28.45 7.68468 17
-    endloop
-  endfacet
-  facet normal 0.309018 -0.951056 0
-    outer loop
-      vertex 29.676 8.08302 17
-      vertex 28.45 7.68468 13.5
-      vertex 29.676 8.08302 13.5
-    endloop
-  endfacet
-  facet normal 0.913546 -0.406736 0
-    outer loop
-      vertex 26.9677 5.64453 17
-      vertex 27.492 6.82213 13.5
-      vertex 27.492 6.82213 17
-    endloop
-  endfacet
-  facet normal 0.913546 -0.406736 0
-    outer loop
-      vertex 27.492 6.82213 13.5
-      vertex 26.9677 5.64453 17
-      vertex 26.9677 5.64453 13.5
-    endloop
-  endfacet
-  facet normal 0.66913 -0.743146 0
-    outer loop
-      vertex 27.492 6.82213 13.5
-      vertex 28.45 7.68468 17
-      vertex 27.492 6.82213 17
-    endloop
-  endfacet
-  facet normal 0.66913 -0.743146 0
-    outer loop
-      vertex 28.45 7.68468 17
-      vertex 27.492 6.82213 13.5
-      vertex 28.45 7.68468 13.5
-    endloop
-  endfacet
-  facet normal 0.913546 0.406736 0
-    outer loop
-      vertex 27.492 3.17787 17
-      vertex 26.9677 4.35547 13.5
-      vertex 26.9677 4.35547 17
-    endloop
-  endfacet
-  facet normal 0.913546 0.406736 0
-    outer loop
-      vertex 26.9677 4.35547 13.5
-      vertex 27.492 3.17787 17
-      vertex 27.492 3.17787 13.5
-    endloop
-  endfacet
-  facet normal -0.500001 0.866025 0
-    outer loop
-      vertex 32.0743 2.69625 13.5
-      vertex 30.958 2.05172 17
-      vertex 32.0743 2.69625 17
-    endloop
-  endfacet
-  facet normal -0.500001 0.866025 0
-    outer loop
-      vertex 30.958 2.05172 17
-      vertex 32.0743 2.69625 13.5
-      vertex 30.958 2.05172 13.5
-    endloop
-  endfacet
-  facet normal -0.809017 0.587786 0
-    outer loop
-      vertex 32.0743 2.69625 13.5
-      vertex 32.832 3.73912 17
-      vertex 32.832 3.73912 13.5
-    endloop
-  endfacet
-  facet normal -0.809017 0.587786 0
-    outer loop
-      vertex 32.832 3.73912 17
-      vertex 32.0743 2.69625 13.5
-      vertex 32.0743 2.69625 17
-    endloop
-  endfacet
-  facet normal -0.978148 0.207912 0
-    outer loop
-      vertex 32.832 3.73912 13.5
-      vertex 33.1 5 17
-      vertex 33.1 5 13.5
-    endloop
-  endfacet
-  facet normal -0.978148 0.207912 0
-    outer loop
-      vertex 33.1 5 17
-      vertex 32.832 3.73912 13.5
-      vertex 32.832 3.73912 17
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 31.6 5 13.5
-      vertex 33.1 5 13.5
-      vertex 32.832 6.26088 13.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 31.4617 5.65078 13.5
-      vertex 32.832 6.26088 13.5
-      vertex 32.0743 7.30375 13.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 33.1 5 13.5
-      vertex 31.6 5 13.5
-      vertex 32.832 3.73912 13.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 31.4617 4.34922 13.5
-      vertex 32.832 3.73912 13.5
-      vertex 31.6 5 13.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 32.832 6.26088 13.5
-      vertex 31.4617 5.65078 13.5
-      vertex 31.6 5 13.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 32.0743 7.30375 13.5
-      vertex 31.0706 6.18903 13.5
-      vertex 31.4617 5.65078 13.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 30.958 7.94827 13.5
-      vertex 31.0706 6.18903 13.5
-      vertex 32.0743 7.30375 13.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 30.958 7.94827 13.5
-      vertex 30.4944 6.52169 13.5
-      vertex 31.0706 6.18903 13.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 30.958 7.94827 13.5
-      vertex 29.8328 6.59123 13.5
-      vertex 30.4944 6.52169 13.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 29.676 8.08302 13.5
-      vertex 29.8328 6.59123 13.5
-      vertex 30.958 7.94827 13.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 29.676 8.08302 13.5
-      vertex 29.2 6.38564 13.5
-      vertex 29.8328 6.59123 13.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 28.45 7.68468 13.5
-      vertex 29.2 6.38564 13.5
-      vertex 29.676 8.08302 13.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 29.2 6.38564 13.5
-      vertex 28.45 7.68468 13.5
-      vertex 28.7056 5.94046 13.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 27.492 6.82213 13.5
-      vertex 28.7056 5.94046 13.5
-      vertex 28.45 7.68468 13.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 26.9677 5.64453 13.5
-      vertex 28.435 5.33266 13.5
-      vertex 27.492 6.82213 13.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 28.7056 5.94046 13.5
-      vertex 27.492 6.82213 13.5
-      vertex 28.435 5.33266 13.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 32.832 3.73912 13.5
-      vertex 31.4617 4.34922 13.5
-      vertex 32.0743 2.69625 13.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 31.0706 3.81097 13.5
-      vertex 32.0743 2.69625 13.5
-      vertex 31.4617 4.34922 13.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 31.0706 3.81097 13.5
-      vertex 30.958 2.05172 13.5
-      vertex 32.0743 2.69625 13.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 30.4944 3.47831 13.5
-      vertex 30.958 2.05172 13.5
-      vertex 31.0706 3.81097 13.5
-    endloop
-  endfacet
-  facet normal -0 0 1
-    outer loop
-      vertex 29.8328 3.40876 13.5
-      vertex 30.958 2.05172 13.5
-      vertex 30.4944 3.47831 13.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 29.8328 3.40876 13.5
-      vertex 29.676 1.91698 13.5
-      vertex 30.958 2.05172 13.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 29.2 3.61436 13.5
-      vertex 29.676 1.91698 13.5
-      vertex 29.8328 3.40876 13.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 28.45 2.31532 13.5
-      vertex 29.2 3.61436 13.5
-      vertex 28.7056 4.05954 13.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 29.2 3.61436 13.5
-      vertex 28.45 2.31532 13.5
-      vertex 29.676 1.91698 13.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 27.492 3.17787 13.5
-      vertex 28.7056 4.05954 13.5
-      vertex 28.435 4.66734 13.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 28.435 5.33266 13.5
-      vertex 26.9677 5.64453 13.5
-      vertex 28.435 4.66734 13.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 28.7056 4.05954 13.5
-      vertex 27.492 3.17787 13.5
-      vertex 28.45 2.31532 13.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 26.9677 4.35547 13.5
-      vertex 28.435 4.66734 13.5
-      vertex 26.9677 5.64453 13.5
-    endloop
-  endfacet
-  facet normal 0 0 1
-    outer loop
-      vertex 28.435 4.66734 13.5
-      vertex 26.9677 4.35547 13.5
-      vertex 27.492 3.17787 13.5
-    endloop
-  endfacet
-  facet normal 0.66913 0.743146 -0
-    outer loop
-      vertex 28.45 2.31532 13.5
-      vertex 27.492 3.17787 17
-      vertex 28.45 2.31532 17
-    endloop
-  endfacet
-  facet normal 0.66913 0.743146 0
-    outer loop
-      vertex 27.492 3.17787 17
-      vertex 28.45 2.31532 13.5
-      vertex 27.492 3.17787 13.5
-    endloop
-  endfacet
-  facet normal -0.104528 0.994522 0
-    outer loop
-      vertex 30.958 2.05172 13.5
-      vertex 29.676 1.91698 17
-      vertex 30.958 2.05172 17
-    endloop
-  endfacet
-  facet normal -0.104528 0.994522 0
-    outer loop
-      vertex 29.676 1.91698 17
-      vertex 30.958 2.05172 13.5
-      vertex 29.676 1.91698 13.5
-    endloop
-  endfacet
-  facet normal 0.309018 0.951056 -0
-    outer loop
-      vertex 29.676 1.91698 13.5
-      vertex 28.45 2.31532 17
-      vertex 29.676 1.91698 17
-    endloop
-  endfacet
-  facet normal 0.309018 0.951056 0
-    outer loop
-      vertex 28.45 2.31532 17
-      vertex 29.676 1.91698 13.5
-      vertex 28.45 2.31532 13.5
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex 21 9 0
-      vertex 21 10 15.5
-      vertex 21 10 0
-    endloop
-  endfacet
-  facet normal -1 -0 0
-    outer loop
-      vertex 21 10 15.5
-      vertex 21 9 0
-      vertex 21 9 15.5
-    endloop
-  endfacet
-  facet normal 1 -0 0
-    outer loop
-      vertex 2 0 0.5
-      vertex 2 1.14214 0
-      vertex 2 1.14214 0.5
-    endloop
-  endfacet
-  facet normal 1 0 0
-    outer loop
-      vertex 2 1.14214 0
-      vertex 2 0 0.5
-      vertex 2 0 0
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 24.5 0 0.5
-      vertex 2.14214 1 0.5
-      vertex 24.5 1 0.5
-    endloop
-  endfacet
-  facet normal 0 0 -1
-    outer loop
-      vertex 2 0 0.5
-      vertex 2.14214 1 0.5
-      vertex 24.5 0 0.5
-    endloop
-  endfacet
-  facet normal -0 0 -1
-    outer loop
-      vertex 2.14214 1 0.5
-      vertex 2 0 0.5
-      vertex 2 1.14214 0.5
-    endloop
-  endfacet
-  facet normal 0.707107 0 -0.707107
-    outer loop
-      vertex 25.5355 0 1.53553
-      vertex 24.5 1 0.5
-      vertex 25.5355 1 1.53553
-    endloop
-  endfacet
-  facet normal 0.707107 0 -0.707107
-    outer loop
-      vertex 24.5 1 0.5
-      vertex 25.5355 0 1.53553
-      vertex 24.5 0 0.5
-    endloop
-  endfacet
-  facet normal -0.707107 0 -0.707107
-    outer loop
-      vertex 27.0711 9 0
-      vertex 26 1 1.07107
-      vertex 26 9 1.07107
-    endloop
-  endfacet
-  facet normal -0.707107 0 -0.707107
-    outer loop
-      vertex 27.0711 0 0
-      vertex 26 1 1.07107
-      vertex 27.0711 9 0
-    endloop
-  endfacet
-  facet normal -0.707107 0 -0.707107
-    outer loop
-      vertex 25.5355 0 1.53553
-      vertex 26 1 1.07107
-      vertex 27.0711 0 0
-    endloop
-  endfacet
-  facet normal -0.707107 0 -0.707107
-    outer loop
-      vertex 26 1 1.07107
-      vertex 25.5355 0 1.53553
-      vertex 25.5355 1 1.53553
-    endloop
-  endfacet
-  facet normal 0.866025 0.5 0
-    outer loop
-      vertex 15.9793 5.5 15.5
-      vertex 14.366 8.29423 7
-      vertex 14.366 8.29423 15.5
-    endloop
-  endfacet
-  facet normal 0.866025 0.5 -7.84851e-008
-    outer loop
-      vertex 18.5773 1 11
-      vertex 14.366 8.29423 7
-      vertex 15.9793 5.5 15.5
-    endloop
-  endfacet
-  facet normal 0.866025 0.5 0
-    outer loop
-      vertex 14.366 8.29423 7
-      vertex 18.5773 1 11
-      vertex 18.5773 1 7
+      vertex -35.8 5 -16.5165
+      vertex -33.7373 1.4273 -16.5319
+      vertex -32.9 -0.0229473 -12.5474
     endloop
   endfacet
   facet normal -0.866025 -0.5 0
     outer loop
-      vertex 13.5 7.79423 7
-      vertex 14.8246 5.5 15.5
-      vertex 13.5 7.79423 15.5
+      vertex -35.8 5 -16.5165
+      vertex -32.9 -0.0229473 -12.5474
+      vertex -35.8 5 -4.38409e-015
     endloop
   endfacet
-  facet normal -0.866025 -0.5 -0
+  facet normal -0.866026 -0.5 -2.63291e-007
     outer loop
-      vertex 17.4226 1 11
-      vertex 13.5 7.79423 7
-      vertex 17.4226 1 7
+      vertex -35.8 5 -4.38409e-015
+      vertex -32.9 -0.0229473 -12.5474
+      vertex -32.9 -0.0229473 -4.02895e-015
     endloop
   endfacet
-  facet normal -0.866025 -0.5 1.76072e-008
+  facet normal 1 0 0
     outer loop
-      vertex 13.5 7.79423 7
-      vertex 17.4226 1 11
-      vertex 14.8246 5.5 15.5
+      vertex 3 5 4.92893
+      vertex 3 9 6
+      vertex 3 6.07107 6
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 3 9 6
+      vertex 3 5 4.92893
+      vertex 3 5 3.67382e-016
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 3 9 6
+      vertex 3 5 3.67382e-016
+      vertex 3 9 -16
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 3 2.64214 -16
+      vertex 3 5 3.67382e-016
+      vertex 3 2.64214 3.67382e-016
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 3 5 3.67382e-016
+      vertex 3 2.64214 -16
+      vertex 3 9 -16
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.5 10 6
+      vertex 3 9 6
+      vertex 2 10 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3 9 6
+      vertex 0.5 10 6
+      vertex 0.5 6.07107 6
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3 9 6
+      vertex 0.5 6.07107 6
+      vertex 3 6.07107 6
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -1 2.14213 -12.1421
+      vertex -1 10 -15.5
+      vertex -1 5.5 -15.5
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -1 10 -15.5
+      vertex -1 2.14213 -12.1421
+      vertex -1 10 -1.22461e-016
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -1 10 -1.22461e-016
+      vertex -1 2.14213 -12.1421
+      vertex -1 5 -1.22461e-016
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -1 5 -1.22461e-016
+      vertex -1 2.14213 -12.1421
+      vertex -1 2.14213 -1.22461e-016
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1 10 -15.5
+      vertex -13.5 7.79423 -15.5
+      vertex -1 5.5 -15.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1 10 -15.5
+      vertex -14.366 8.29423 -15.5
+      vertex -13.5 7.79423 -15.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -21 10 -15.5
+      vertex -14.366 8.29423 -15.5
+      vertex -1 10 -15.5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -21 9 -15.5
+      vertex -14.366 8.29423 -15.5
+      vertex -21 10 -15.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.366 8.29423 -15.5
+      vertex -21 9 -15.5
+      vertex -15.9793 5.5 -15.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21.3737 5.5 -15.5
+      vertex -21 9 -15.5
+      vertex -21.3737 9 -15.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -21 9 -15.5
+      vertex -21.3737 5.5 -15.5
+      vertex -15.9793 5.5 -15.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1 5.5 -15.5
+      vertex -13.5 7.79423 -15.5
+      vertex -14.8246 5.5 -15.5
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -26 1 -11
+      vertex -26 9 -13.8162
+      vertex -26 9 -1.07107
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -26 1 -11
+      vertex -26 9 -1.07107
+      vertex -26 1 -1.07107
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -26 9 -13.8162
+      vertex -26 1 -11
+      vertex -26 3.81618 -13.8162
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -17.4226 1 -7
+      vertex -24.5 1 -0.5
+      vertex -2.14214 1 -0.5
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -18.5773 1 -7
+      vertex -24.5 1 -0.5
+      vertex -17.4226 1 -7
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -2.14214 1 -11
+      vertex -17.4226 1 -7
+      vertex -2.14214 1 -0.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -17.4226 1 -7
+      vertex -2.14214 1 -11
+      vertex -17.4226 1 -11
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -24.5 1 -0.5
+      vertex -18.5773 1 -7
+      vertex -25.5355 1 -1.53553
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -26 1 -11
+      vertex -18.5773 1 -7
+      vertex -18.5773 1 -11
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -18.5773 1 -7
+      vertex -26 1 -11
+      vertex -25.5355 1 -1.53553
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -25.5355 1 -1.53553
+      vertex -26 1 -11
+      vertex -26 1 -1.07107
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -26 9 -1.07107
+      vertex -21 9 -2.57167e-015
+      vertex -27.0711 9 -3.31514e-015
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -26 9 -13.8162
+      vertex -21 9 -2.57167e-015
+      vertex -26 9 -1.07107
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -21.3737 9 -15.5
+      vertex -21 9 -2.57167e-015
+      vertex -26 9 -13.8162
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -21 9 -2.57167e-015
+      vertex -21.3737 9 -15.5
+      vertex -21 9 -15.5
+    endloop
+  endfacet
+  facet normal -1.97814e-007 0.707107 0.707107
+    outer loop
+      vertex -1 5.5 -15.5
+      vertex -2.14214 1 -11
+      vertex -1 2.14213 -12.1421
+    endloop
+  endfacet
+  facet normal 0 0.707107 0.707107
+    outer loop
+      vertex -2.14214 1 -11
+      vertex -1 5.5 -15.5
+      vertex -14.8246 5.5 -15.5
+    endloop
+  endfacet
+  facet normal 0 0.707107 0.707107
+    outer loop
+      vertex -2.14214 1 -11
+      vertex -14.8246 5.5 -15.5
+      vertex -17.4226 1 -11
+    endloop
+  endfacet
+  facet normal 0 0.707107 0.707107
+    outer loop
+      vertex -21.3737 5.5 -15.5
+      vertex -26 1 -11
+      vertex -18.5773 1 -11
+    endloop
+  endfacet
+  facet normal -0 0.707107 0.707107
+    outer loop
+      vertex -21.3737 5.5 -15.5
+      vertex -18.5773 1 -11
+      vertex -15.9793 5.5 -15.5
+    endloop
+  endfacet
+  facet normal -5.82301e-008 0.707107 0.707107
+    outer loop
+      vertex -26 1 -11
+      vertex -21.3737 5.5 -15.5
+      vertex -26 3.81618 -13.8162
+    endloop
+  endfacet
+  facet normal -0.707107 0.707107 0
+    outer loop
+      vertex -1 2.14213 -1.22461e-016
+      vertex -2 1.14214 -0.5
+      vertex -2 1.14214 -2.44921e-016
+    endloop
+  endfacet
+  facet normal -0.707107 0.707107 0
+    outer loop
+      vertex -2 1.14214 -0.5
+      vertex -2.14214 1 -11
+      vertex -2.14214 1 -0.5
+    endloop
+  endfacet
+  facet normal -0.707107 0.707107 -2.29767e-009
+    outer loop
+      vertex -1 2.14213 -1.22461e-016
+      vertex -2.14214 1 -11
+      vertex -2 1.14214 -0.5
+    endloop
+  endfacet
+  facet normal -0.707107 0.707107 0
+    outer loop
+      vertex -2.14214 1 -11
+      vertex -1 2.14213 -1.22461e-016
+      vertex -1 2.14213 -12.1421
+    endloop
+  endfacet
+  facet normal 0.34202 0 0.939693
+    outer loop
+      vertex -26 9 -13.8162
+      vertex -21.3737 5.5 -15.5
+      vertex -21.3737 9 -15.5
+    endloop
+  endfacet
+  facet normal 0.34202 0 0.939693
+    outer loop
+      vertex -21.3737 5.5 -15.5
+      vertex -26 9 -13.8162
+      vertex -26 3.81618 -13.8162
+    endloop
+  endfacet
+  facet normal 0.978148 -0.207911 0
+    outer loop
+      vertex -31.6 5 -3.86976e-015
+      vertex -31.4617 5.65078 -13.5
+      vertex -31.4617 5.65078 -3.85282e-015
+    endloop
+  endfacet
+  facet normal 0.978148 -0.207911 0
+    outer loop
+      vertex -31.4617 5.65078 -13.5
+      vertex -31.6 5 -3.86976e-015
+      vertex -31.6 5 -13.5
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -28.435 4.66734 -13.5
+      vertex -28.435 5.33266 -3.48216e-015
+      vertex -28.435 5.33266 -13.5
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -28.435 5.33266 -3.48216e-015
+      vertex -28.435 4.66734 -13.5
+      vertex -28.435 4.66734 -3.48216e-015
+    endloop
+  endfacet
+  facet normal 0.104527 -0.994522 0
+    outer loop
+      vertex -30.4944 6.52169 -13.5
+      vertex -29.8328 6.59123 -3.65334e-015
+      vertex -30.4944 6.52169 -3.73437e-015
+    endloop
+  endfacet
+  facet normal 0.104527 -0.994522 0
+    outer loop
+      vertex -29.8328 6.59123 -3.65334e-015
+      vertex -30.4944 6.52169 -13.5
+      vertex -29.8328 6.59123 -13.5
+    endloop
+  endfacet
+  facet normal -0.669129 -0.743146 -9.4538e-008
+    outer loop
+      vertex -29.2 6.38564 -13.5
+      vertex -28.7056 5.94046 -3.5153e-015
+      vertex -29.2 6.38564 -3.57585e-015
+    endloop
+  endfacet
+  facet normal -0.669131 -0.743145 -0
+    outer loop
+      vertex -28.7056 5.94046 -3.5153e-015
+      vertex -29.2 6.38564 -13.5
+      vertex -28.7056 5.94046 -13.5
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 -0
+    outer loop
+      vertex -30.4944 3.47831 -13.5
+      vertex -31.0706 3.81097 -3.80493e-015
+      vertex -30.4944 3.47831 -3.73437e-015
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 0
+    outer loop
+      vertex -31.0706 3.81097 -3.80493e-015
+      vertex -30.4944 3.47831 -13.5
+      vertex -31.0706 3.81097 -13.5
+    endloop
+  endfacet
+  facet normal 0.104527 0.994522 -0
+    outer loop
+      vertex -29.8328 3.40876 -13.5
+      vertex -30.4944 3.47831 -3.73437e-015
+      vertex -29.8328 3.40876 -3.65334e-015
+    endloop
+  endfacet
+  facet normal 0.104527 0.994522 0
+    outer loop
+      vertex -30.4944 3.47831 -3.73437e-015
+      vertex -29.8328 3.40876 -13.5
+      vertex -30.4944 3.47831 -13.5
+    endloop
+  endfacet
+  facet normal 0.5 -0.866025 0
+    outer loop
+      vertex -31.0706 6.18903 -13.5
+      vertex -30.4944 6.52169 -3.73437e-015
+      vertex -31.0706 6.18903 -3.80493e-015
+    endloop
+  endfacet
+  facet normal 0.5 -0.866025 0
+    outer loop
+      vertex -30.4944 6.52169 -3.73437e-015
+      vertex -31.0706 6.18903 -13.5
+      vertex -30.4944 6.52169 -13.5
+    endloop
+  endfacet
+  facet normal 0.809017 -0.587785 0
+    outer loop
+      vertex -31.4617 5.65078 -3.85282e-015
+      vertex -31.0706 6.18903 -13.5
+      vertex -31.0706 6.18903 -3.80493e-015
+    endloop
+  endfacet
+  facet normal 0.809017 -0.587785 0
+    outer loop
+      vertex -31.0706 6.18903 -13.5
+      vertex -31.4617 5.65078 -3.85282e-015
+      vertex -31.4617 5.65078 -13.5
+    endloop
+  endfacet
+  facet normal -0.309017 -0.951057 0
+    outer loop
+      vertex -29.8328 6.59123 -13.5
+      vertex -29.2 6.38564 -3.57585e-015
+      vertex -29.8328 6.59123 -3.65334e-015
+    endloop
+  endfacet
+  facet normal -0.309016 -0.951057 -4.36594e-008
+    outer loop
+      vertex -29.2 6.38564 -3.57585e-015
+      vertex -29.8328 6.59123 -13.5
+      vertex -29.2 6.38564 -13.5
+    endloop
+  endfacet
+  facet normal -0.913546 -0.406736 0
+    outer loop
+      vertex -28.435 5.33266 -13.5
+      vertex -28.7056 5.94046 -3.5153e-015
+      vertex -28.7056 5.94046 -13.5
+    endloop
+  endfacet
+  facet normal -0.913546 -0.406736 0
+    outer loop
+      vertex -28.7056 5.94046 -3.5153e-015
+      vertex -28.435 5.33266 -13.5
+      vertex -28.435 5.33266 -3.48216e-015
+    endloop
+  endfacet
+  facet normal -0.913546 0.406736 0
+    outer loop
+      vertex -28.7056 4.05954 -13.5
+      vertex -28.435 4.66734 -3.48216e-015
+      vertex -28.435 4.66734 -13.5
+    endloop
+  endfacet
+  facet normal -0.913546 0.406736 0
+    outer loop
+      vertex -28.435 4.66734 -3.48216e-015
+      vertex -28.7056 4.05954 -13.5
+      vertex -28.7056 4.05954 -3.5153e-015
+    endloop
+  endfacet
+  facet normal -0.309017 0.951057 -4.36595e-008
+    outer loop
+      vertex -29.2 3.61436 -13.5
+      vertex -29.8328 3.40876 -3.65334e-015
+      vertex -29.2 3.61436 -3.57585e-015
+    endloop
+  endfacet
+  facet normal -0.309016 0.951057 0
+    outer loop
+      vertex -29.8328 3.40876 -3.65334e-015
+      vertex -29.2 3.61436 -13.5
+      vertex -29.8328 3.40876 -13.5
+    endloop
+  endfacet
+  facet normal 0.809017 0.587785 0
+    outer loop
+      vertex -31.0706 3.81097 -3.80493e-015
+      vertex -31.4617 4.34922 -13.5
+      vertex -31.4617 4.34922 -3.85282e-015
+    endloop
+  endfacet
+  facet normal 0.809017 0.587785 0
+    outer loop
+      vertex -31.4617 4.34922 -13.5
+      vertex -31.0706 3.81097 -3.80493e-015
+      vertex -31.0706 3.81097 -13.5
+    endloop
+  endfacet
+  facet normal 0.978148 0.207911 0
+    outer loop
+      vertex -31.4617 4.34922 -3.85282e-015
+      vertex -31.6 5 -13.5
+      vertex -31.6 5 -3.86976e-015
+    endloop
+  endfacet
+  facet normal 0.978148 0.207911 0
+    outer loop
+      vertex -31.6 5 -13.5
+      vertex -31.4617 4.34922 -3.85282e-015
+      vertex -31.4617 4.34922 -13.5
+    endloop
+  endfacet
+  facet normal -0.669129 0.743146 0
+    outer loop
+      vertex -28.7056 4.05954 -13.5
+      vertex -29.2 3.61436 -3.57585e-015
+      vertex -28.7056 4.05954 -3.5153e-015
+    endloop
+  endfacet
+  facet normal -0.669131 0.743145 -9.45382e-008
+    outer loop
+      vertex -29.2 3.61436 -3.57585e-015
+      vertex -28.7056 4.05954 -13.5
+      vertex -29.2 3.61436 -13.5
+    endloop
+  endfacet
+  facet normal 0.978148 -0.207912 0
+    outer loop
+      vertex -33.1 5 -13.5
+      vertex -32.832 6.26088 -17
+      vertex -32.832 6.26088 -13.5
+    endloop
+  endfacet
+  facet normal 0.978148 -0.207912 0
+    outer loop
+      vertex -32.832 6.26088 -17
+      vertex -33.1 5 -13.5
+      vertex -33.1 5 -17
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -26.9677 4.35547 -17
+      vertex -26.9677 5.64453 -13.5
+      vertex -26.9677 5.64453 -17
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -26.9677 5.64453 -13.5
+      vertex -26.9677 4.35547 -17
+      vertex -26.9677 4.35547 -13.5
+    endloop
+  endfacet
+  facet normal 0.104528 -0.994522 0
+    outer loop
+      vertex -30.958 7.94827 -17
+      vertex -29.676 8.08302 -13.5
+      vertex -30.958 7.94827 -13.5
+    endloop
+  endfacet
+  facet normal 0.104528 -0.994522 0
+    outer loop
+      vertex -29.676 8.08302 -13.5
+      vertex -30.958 7.94827 -17
+      vertex -29.676 8.08302 -17
+    endloop
+  endfacet
+  facet normal 0.500001 -0.866025 0
+    outer loop
+      vertex -32.0743 7.30375 -17
+      vertex -30.958 7.94827 -13.5
+      vertex -32.0743 7.30375 -13.5
+    endloop
+  endfacet
+  facet normal 0.500001 -0.866025 0
+    outer loop
+      vertex -30.958 7.94827 -13.5
+      vertex -32.0743 7.30375 -17
+      vertex -30.958 7.94827 -17
+    endloop
+  endfacet
+  facet normal 0.809017 -0.587786 0
+    outer loop
+      vertex -32.832 6.26088 -13.5
+      vertex -32.0743 7.30375 -17
+      vertex -32.0743 7.30375 -13.5
+    endloop
+  endfacet
+  facet normal 0.809017 -0.587786 0
+    outer loop
+      vertex -32.0743 7.30375 -17
+      vertex -32.832 6.26088 -13.5
+      vertex -32.832 6.26088 -17
+    endloop
+  endfacet
+  facet normal -0.309017 -0.951056 0
+    outer loop
+      vertex -29.676 8.08302 -17
+      vertex -28.45 7.68468 -13.5
+      vertex -29.676 8.08302 -13.5
+    endloop
+  endfacet
+  facet normal -0.309017 -0.951056 -0
+    outer loop
+      vertex -28.45 7.68468 -13.5
+      vertex -29.676 8.08302 -17
+      vertex -28.45 7.68468 -17
+    endloop
+  endfacet
+  facet normal -0.669131 -0.743145 0
+    outer loop
+      vertex -28.45 7.68468 -17
+      vertex -27.492 6.82213 -13.5
+      vertex -28.45 7.68468 -13.5
+    endloop
+  endfacet
+  facet normal -0.669131 -0.743145 -0
+    outer loop
+      vertex -27.492 6.82213 -13.5
+      vertex -28.45 7.68468 -17
+      vertex -27.492 6.82213 -17
+    endloop
+  endfacet
+  facet normal -0.913545 0.406737 0
+    outer loop
+      vertex -27.492 3.17787 -17
+      vertex -26.9677 4.35547 -13.5
+      vertex -26.9677 4.35547 -17
+    endloop
+  endfacet
+  facet normal -0.913545 0.406737 0
+    outer loop
+      vertex -26.9677 4.35547 -13.5
+      vertex -27.492 3.17787 -17
+      vertex -27.492 3.17787 -13.5
+    endloop
+  endfacet
+  facet normal -0.913545 -0.406737 0
+    outer loop
+      vertex -26.9677 5.64453 -17
+      vertex -27.492 6.82213 -13.5
+      vertex -27.492 6.82213 -17
+    endloop
+  endfacet
+  facet normal -0.913545 -0.406737 0
+    outer loop
+      vertex -27.492 6.82213 -13.5
+      vertex -26.9677 5.64453 -17
+      vertex -26.9677 5.64453 -13.5
+    endloop
+  endfacet
+  facet normal 0.500001 0.866025 -0
+    outer loop
+      vertex -30.958 2.05172 -17
+      vertex -32.0743 2.69625 -13.5
+      vertex -30.958 2.05172 -13.5
+    endloop
+  endfacet
+  facet normal 0.500001 0.866025 0
+    outer loop
+      vertex -32.0743 2.69625 -13.5
+      vertex -30.958 2.05172 -17
+      vertex -32.0743 2.69625 -17
+    endloop
+  endfacet
+  facet normal 0.809017 0.587786 0
+    outer loop
+      vertex -32.0743 2.69625 -13.5
+      vertex -32.832 3.73912 -17
+      vertex -32.832 3.73912 -13.5
+    endloop
+  endfacet
+  facet normal 0.809017 0.587786 0
+    outer loop
+      vertex -32.832 3.73912 -17
+      vertex -32.0743 2.69625 -13.5
+      vertex -32.0743 2.69625 -17
+    endloop
+  endfacet
+  facet normal 0.978148 0.207912 0
+    outer loop
+      vertex -32.832 3.73912 -13.5
+      vertex -33.1 5 -17
+      vertex -33.1 5 -13.5
+    endloop
+  endfacet
+  facet normal 0.978148 0.207912 0
+    outer loop
+      vertex -33.1 5 -17
+      vertex -32.832 3.73912 -13.5
+      vertex -32.832 3.73912 -17
     endloop
   endfacet
   facet normal 0 0 -1
     outer loop
-      vertex 17.4226 1 7
-      vertex 14.366 8.29423 7
-      vertex 18.5773 1 7
+      vertex -28.435 4.66734 -13.5
+      vertex -26.9677 4.35547 -13.5
+      vertex -27.492 3.17787 -13.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -26.9677 4.35547 -13.5
+      vertex -28.435 4.66734 -13.5
+      vertex -26.9677 5.64453 -13.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.435 5.33266 -13.5
+      vertex -26.9677 5.64453 -13.5
+      vertex -28.435 4.66734 -13.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.7056 4.05954 -13.5
+      vertex -27.492 3.17787 -13.5
+      vertex -28.45 2.31532 -13.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -27.492 3.17787 -13.5
+      vertex -28.7056 4.05954 -13.5
+      vertex -28.435 4.66734 -13.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.45 2.31532 -13.5
+      vertex -29.2 3.61436 -13.5
+      vertex -28.7056 4.05954 -13.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -29.676 1.91698 -13.5
+      vertex -29.2 3.61436 -13.5
+      vertex -28.45 2.31532 -13.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -29.676 1.91698 -13.5
+      vertex -29.8328 3.40876 -13.5
+      vertex -29.2 3.61436 -13.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -29.676 1.91698 -13.5
+      vertex -30.4944 3.47831 -13.5
+      vertex -29.8328 3.40876 -13.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -30.958 2.05172 -13.5
+      vertex -30.4944 3.47831 -13.5
+      vertex -29.676 1.91698 -13.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -30.958 2.05172 -13.5
+      vertex -31.0706 3.81097 -13.5
+      vertex -30.4944 3.47831 -13.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -32.0743 2.69625 -13.5
+      vertex -31.0706 3.81097 -13.5
+      vertex -30.958 2.05172 -13.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -32.832 3.73912 -13.5
+      vertex -31.4617 4.34922 -13.5
+      vertex -32.0743 2.69625 -13.5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -31.0706 3.81097 -13.5
+      vertex -32.0743 2.69625 -13.5
+      vertex -31.4617 4.34922 -13.5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -26.9677 5.64453 -13.5
+      vertex -28.435 5.33266 -13.5
+      vertex -27.492 6.82213 -13.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -28.7056 5.94046 -13.5
+      vertex -27.492 6.82213 -13.5
+      vertex -28.435 5.33266 -13.5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -27.492 6.82213 -13.5
+      vertex -28.7056 5.94046 -13.5
+      vertex -28.45 7.68468 -13.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -29.2 6.38564 -13.5
+      vertex -28.45 7.68468 -13.5
+      vertex -28.7056 5.94046 -13.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -29.2 6.38564 -13.5
+      vertex -29.676 8.08302 -13.5
+      vertex -28.45 7.68468 -13.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -29.8328 6.59123 -13.5
+      vertex -29.676 8.08302 -13.5
+      vertex -29.2 6.38564 -13.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -30.4944 6.52169 -13.5
+      vertex -29.676 8.08302 -13.5
+      vertex -29.8328 6.59123 -13.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -30.4944 6.52169 -13.5
+      vertex -30.958 7.94827 -13.5
+      vertex -29.676 8.08302 -13.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -31.0706 6.18903 -13.5
+      vertex -30.958 7.94827 -13.5
+      vertex -30.4944 6.52169 -13.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -32.0743 7.30375 -13.5
+      vertex -31.0706 6.18903 -13.5
+      vertex -31.4617 5.65078 -13.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -31.0706 6.18903 -13.5
+      vertex -32.0743 7.30375 -13.5
+      vertex -30.958 7.94827 -13.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -32.832 6.26088 -13.5
+      vertex -31.4617 5.65078 -13.5
+      vertex -31.6 5 -13.5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -31.4617 4.34922 -13.5
+      vertex -32.832 3.73912 -13.5
+      vertex -31.6 5 -13.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -33.1 5 -13.5
+      vertex -31.6 5 -13.5
+      vertex -32.832 3.73912 -13.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -31.4617 5.65078 -13.5
+      vertex -32.832 6.26088 -13.5
+      vertex -32.0743 7.30375 -13.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -31.6 5 -13.5
+      vertex -33.1 5 -13.5
+      vertex -32.832 6.26088 -13.5
+    endloop
+  endfacet
+  facet normal -0.669131 0.743145 0
+    outer loop
+      vertex -27.492 3.17787 -17
+      vertex -28.45 2.31532 -13.5
+      vertex -27.492 3.17787 -13.5
+    endloop
+  endfacet
+  facet normal -0.669131 0.743145 0
+    outer loop
+      vertex -28.45 2.31532 -13.5
+      vertex -27.492 3.17787 -17
+      vertex -28.45 2.31532 -17
+    endloop
+  endfacet
+  facet normal 0.104528 0.994522 -0
+    outer loop
+      vertex -29.676 1.91698 -17
+      vertex -30.958 2.05172 -13.5
+      vertex -29.676 1.91698 -13.5
+    endloop
+  endfacet
+  facet normal 0.104528 0.994522 0
+    outer loop
+      vertex -30.958 2.05172 -13.5
+      vertex -29.676 1.91698 -17
+      vertex -30.958 2.05172 -17
+    endloop
+  endfacet
+  facet normal -0.309017 0.951056 0
+    outer loop
+      vertex -28.45 2.31532 -17
+      vertex -29.676 1.91698 -13.5
+      vertex -28.45 2.31532 -13.5
+    endloop
+  endfacet
+  facet normal -0.309017 0.951056 0
+    outer loop
+      vertex -29.676 1.91698 -13.5
+      vertex -28.45 2.31532 -17
+      vertex -29.676 1.91698 -17
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -21 9 -2.57167e-015
+      vertex -21 10 -15.5
+      vertex -21 10 -2.57167e-015
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -21 10 -15.5
+      vertex -21 9 -2.57167e-015
+      vertex -21 9 -15.5
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -2 0 -0.5
+      vertex -2 1.14214 -2.44921e-016
+      vertex -2 1.14214 -0.5
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -2 1.14214 -2.44921e-016
+      vertex -2 0 -0.5
+      vertex -2 0 -2.44921e-016
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.14214 1 -0.5
+      vertex -2 0 -0.5
+      vertex -2 1.14214 -0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -24.5 0 -0.5
+      vertex -2.14214 1 -0.5
+      vertex -24.5 1 -0.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.14214 1 -0.5
+      vertex -24.5 0 -0.5
+      vertex -2 0 -0.5
+    endloop
+  endfacet
+  facet normal -0.707107 0 0.707107
+    outer loop
+      vertex -25.5355 0 -1.53553
+      vertex -24.5 1 -0.5
+      vertex -25.5355 1 -1.53553
+    endloop
+  endfacet
+  facet normal -0.707107 0 0.707107
+    outer loop
+      vertex -24.5 1 -0.5
+      vertex -25.5355 0 -1.53553
+      vertex -24.5 0 -0.5
+    endloop
+  endfacet
+  facet normal 0.707107 0 0.707107
+    outer loop
+      vertex -27.0711 9 -3.31514e-015
+      vertex -26 1 -1.07107
+      vertex -26 9 -1.07107
+    endloop
+  endfacet
+  facet normal 0.707107 -0 0.707107
+    outer loop
+      vertex -27.0711 0 -3.31514e-015
+      vertex -26 1 -1.07107
+      vertex -27.0711 9 -3.31514e-015
+    endloop
+  endfacet
+  facet normal 0.707107 -7.15754e-016 0.707107
+    outer loop
+      vertex -25.5355 0 -1.53553
+      vertex -26 1 -1.07107
+      vertex -27.0711 0 -3.31514e-015
+    endloop
+  endfacet
+  facet normal 0.707107 0 0.707107
+    outer loop
+      vertex -26 1 -1.07107
+      vertex -25.5355 0 -1.53553
+      vertex -25.5355 1 -1.53553
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex -15.9793 5.5 -15.5
+      vertex -14.366 8.29423 -7
+      vertex -14.366 8.29423 -15.5
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 7.84851e-008
+    outer loop
+      vertex -18.5773 1 -11
+      vertex -14.366 8.29423 -7
+      vertex -15.9793 5.5 -15.5
+    endloop
+  endfacet
+  facet normal -0.866025 0.5 0
+    outer loop
+      vertex -14.366 8.29423 -7
+      vertex -18.5773 1 -11
+      vertex -18.5773 1 -7
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 -0
+    outer loop
+      vertex -13.5 7.79423 -15.5
+      vertex -14.366 8.29423 -7
+      vertex -13.5 7.79423 -7
+    endloop
+  endfacet
+  facet normal 0.5 0.866025 0
+    outer loop
+      vertex -14.366 8.29423 -7
+      vertex -13.5 7.79423 -15.5
+      vertex -14.366 8.29423 -15.5
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex -13.5 7.79423 -7
+      vertex -14.8246 5.5 -15.5
+      vertex -13.5 7.79423 -15.5
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 0
+    outer loop
+      vertex -17.4226 1 -11
+      vertex -13.5 7.79423 -7
+      vertex -17.4226 1 -7
+    endloop
+  endfacet
+  facet normal 0.866025 -0.5 -1.76072e-008
+    outer loop
+      vertex -13.5 7.79423 -7
+      vertex -17.4226 1 -11
+      vertex -14.8246 5.5 -15.5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -14.366 8.29423 -7
+      vertex -17.4226 1 -7
+      vertex -13.5 7.79423 -7
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -17.4226 1 -7
+      vertex -14.366 8.29423 -7
+      vertex -18.5773 1 -7
+    endloop
+  endfacet
+  facet normal 0 -0.939693 -0.342019
+    outer loop
+      vertex -32.9 -0.0229473 -12.5474
+      vertex -27.0868 0 -12.6105
+      vertex -27.1 -0.0229473 -12.5474
+    endloop
+  endfacet
+  facet normal 2.96371e-007 -0.939693 -0.34202
+    outer loop
+      vertex -33.2952 1.59766 -17
+      vertex -32.9 -0.0229473 -12.5474
+      vertex -33.7373 1.4273 -16.5319
+    endloop
+  endfacet
+  facet normal -1.06407e-008 -0.939693 -0.34202
+    outer loop
+      vertex -32.9 -0.0229473 -12.5474
+      vertex -33.2952 1.59766 -17
+      vertex -27.0868 0 -12.6105
+    endloop
+  endfacet
+  facet normal -0 -0.939693 -0.34202
+    outer loop
+      vertex 1.95552 1.59766 -17
+      vertex -27.0868 0 -12.6105
+      vertex -33.2952 1.59766 -17
+    endloop
+  endfacet
+  facet normal 0 -0.939693 -0.34202
+    outer loop
+      vertex -27.0868 0 -12.6105
+      vertex 1.95552 1.59766 -17
+      vertex 0.357864 0 -12.6105
+    endloop
+  endfacet
+  facet normal -0.612374 0.353554 -0.707105
+    outer loop
+      vertex -35.2506 4.98453 -17
+      vertex -32.9 10.0229 -16.5165
+      vertex -32.3417 10.0229 -17
+    endloop
+  endfacet
+  facet normal -0.612373 0.353554 -0.707106
+    outer loop
+      vertex -35.8 5 -16.5165
+      vertex -35.2506 4.98453 -17
+      vertex -35.7911 4.98453 -16.5319
+    endloop
+  endfacet
+  facet normal -0.612373 0.353554 -0.707106
+    outer loop
+      vertex -35.2506 4.98453 -17
+      vertex -35.8 5 -16.5165
+      vertex -32.9 10.0229 -16.5165
+    endloop
+  endfacet
+  facet normal -0.612371 -0.353553 -0.707109
+    outer loop
+      vertex -33.7373 1.4273 -16.5319
+      vertex -35.2506 4.98453 -17
+      vertex -33.2952 1.59766 -17
+    endloop
+  endfacet
+  facet normal -0.612373 -0.353553 -0.707106
+    outer loop
+      vertex -35.2506 4.98453 -17
+      vertex -33.7373 1.4273 -16.5319
+      vertex -35.7911 4.98453 -16.5319
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 0.5 5 4.92893
+      vertex 3 5 3.67382e-016
+      vertex 3 5 4.92893
+    endloop
+  endfacet
+  facet normal -0 -1 0
+    outer loop
+      vertex 3 5 3.67382e-016
+      vertex 0.5 5 4.92893
+      vertex 0.5 5 6.12303e-017
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0.5 10 6.12303e-017
+      vertex 0.5 6.07107 6
+      vertex 0.5 10 6
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0.5 5 4.92893
+      vertex 0.5 10 6.12303e-017
+      vertex 0.5 5 6.12303e-017
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 0.5 10 6.12303e-017
+      vertex 0.5 5 4.92893
+      vertex 0.5 6.07107 6
+    endloop
+  endfacet
+  facet normal 0 -0.707107 0.707107
+    outer loop
+      vertex 0.5 5 4.92893
+      vertex 3 6.07107 6
+      vertex 0.5 6.07107 6
+    endloop
+  endfacet
+  facet normal 0 -0.707107 0.707107
+    outer loop
+      vertex 3 6.07107 6
+      vertex 0.5 5 4.92893
+      vertex 3 5 4.92893
+    endloop
+  endfacet
+  facet normal 0.707107 -0.707107 0
+    outer loop
+      vertex 0.357864 0 -12.6105
+      vertex 3 2.64214 3.67382e-016
+      vertex 0.357864 0 4.38242e-017
+    endloop
+  endfacet
+  facet normal 0.707107 -0.707107 0
+    outer loop
+      vertex 0.357864 0 -12.6105
+      vertex 3 2.64214 -16
+      vertex 3 2.64214 3.67382e-016
+    endloop
+  endfacet
+  facet normal 0.707107 -0.707107 6.69851e-009
+    outer loop
+      vertex 1.95552 1.59766 -17
+      vertex 3 2.64214 -16
+      vertex 0.357864 0 -12.6105
+    endloop
+  endfacet
+  facet normal 0.707107 -0.707107 -8.42937e-008
+    outer loop
+      vertex 3 2.64214 -16
+      vertex 1.95552 1.59766 -17
+      vertex 2 1.64214 -17
+    endloop
+  endfacet
+  facet normal 0.707107 0 -0.707107
+    outer loop
+      vertex 3 2.64214 -16
+      vertex 2 10 -17
+      vertex 3 9 -16
+    endloop
+  endfacet
+  facet normal 0.707107 0 -0.707107
+    outer loop
+      vertex 2 10 -17
+      vertex 3 2.64214 -16
+      vertex 2 1.64214 -17
+    endloop
+  endfacet
+  facet normal 0.707107 0.707107 -0
+    outer loop
+      vertex 3 9 -16
+      vertex 2 10 6
+      vertex 3 9 6
+    endloop
+  endfacet
+  facet normal 0.707107 0.707107 0
+    outer loop
+      vertex 2 10 6
+      vertex 3 9 -16
+      vertex 2 10 -17
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -20.8593 5.92 -16.5
+      vertex -21.9133 5.43233 -16.5
+      vertex -21.8713 5.92 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.2493 4.67899 -16.5
+      vertex -21.5023 4.09999 -16.5
+      vertex -21.986 3.73111 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.145 4.59776 -16.5
+      vertex -22.0393 5.01866 -16.5
+      vertex -21.9133 5.43233 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.5023 4.09999 -16.5
+      vertex -22.2493 4.67899 -16.5
+      vertex -22.0393 5.01866 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.986 3.73111 -16.5
+      vertex -22.5318 4.42732 -16.5
+      vertex -22.2493 4.67899 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.5787 3.50977 -16.5
+      vertex -22.5318 4.42732 -16.5
+      vertex -21.986 3.73111 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.5787 3.50977 -16.5
+      vertex -22.8755 4.27632 -16.5
+      vertex -22.5318 4.42732 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.2803 3.436 -16.5
+      vertex -22.8755 4.27632 -16.5
+      vertex -22.5787 3.50977 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.2803 3.436 -16.5
+      vertex -23.2803 4.226 -16.5
+      vertex -22.8755 4.27632 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.7517 3.46945 -16.5
+      vertex -23.2803 4.226 -16.5
+      vertex -23.2803 3.436 -16.5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -23.2803 4.226 -16.5
+      vertex -23.7517 3.46945 -16.5
+      vertex -23.6977 4.27499 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.182 3.56976 -16.5
+      vertex -23.6977 4.27499 -16.5
+      vertex -23.7517 3.46945 -16.5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -23.6977 4.27499 -16.5
+      vertex -24.182 3.56976 -16.5
+      vertex -24.046 4.422 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.5713 3.737 -16.5
+      vertex -24.046 4.422 -16.5
+      vertex -24.182 3.56976 -16.5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -24.046 4.422 -16.5
+      vertex -24.5713 3.737 -16.5
+      vertex -24.3253 4.66699 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.9115 3.96721 -16.5
+      vertex -24.3253 4.66699 -16.5
+      vertex -24.5713 3.737 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.1948 4.25655 -16.5
+      vertex -24.3253 4.66699 -16.5
+      vertex -24.9115 3.96721 -16.5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -24.3253 4.66699 -16.5
+      vertex -25.1948 4.25655 -16.5
+      vertex -24.5297 5.00266 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.4213 4.605 -16.5
+      vertex -24.5297 5.00266 -16.5
+      vertex -25.1948 4.25655 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.9133 5.43233 -16.5
+      vertex -20.8593 5.92 -16.5
+      vertex -20.9307 5.20444 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.9123 6.40233 -16.5
+      vertex -20.8593 5.92 -16.5
+      vertex -21.8713 5.92 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -21.9133 5.43233 -16.5
+      vertex -20.9307 5.20444 -16.5
+      vertex -21.145 4.59776 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.8593 5.92 -16.5
+      vertex -21.9123 6.40233 -16.5
+      vertex -20.9306 6.63222 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.0393 5.01866 -16.5
+      vertex -21.145 4.59776 -16.5
+      vertex -21.5023 4.09999 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.0353 6.808 -16.5
+      vertex -20.9306 6.63222 -16.5
+      vertex -21.9123 6.40233 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -20.9306 6.63222 -16.5
+      vertex -22.0353 6.808 -16.5
+      vertex -21.1446 7.23155 -16.5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -21.1446 7.23155 -16.5
+      vertex -22.0353 6.808 -16.5
+      vertex -21.5013 7.71799 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.2403 7.13699 -16.5
+      vertex -21.5013 7.71799 -16.5
+      vertex -22.0353 6.808 -16.5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -21.5013 7.71799 -16.5
+      vertex -22.2403 7.13699 -16.5
+      vertex -21.985 8.07687 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.521 7.37978 -16.5
+      vertex -21.985 8.07687 -16.5
+      vertex -22.2403 7.13699 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.521 7.37978 -16.5
+      vertex -22.5804 8.29222 -16.5
+      vertex -21.985 8.07687 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.87 7.52544 -16.5
+      vertex -22.5804 8.29222 -16.5
+      vertex -22.521 7.37978 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.2873 8.364 -16.5
+      vertex -22.87 7.52544 -16.5
+      vertex -23.2873 7.57399 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -22.87 7.52544 -16.5
+      vertex -23.2873 8.364 -16.5
+      vertex -22.5804 8.29222 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.6988 7.5251 -16.5
+      vertex -23.2873 8.364 -16.5
+      vertex -23.2873 7.57399 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -23.6988 7.5251 -16.5
+      vertex -23.9943 8.29144 -16.5
+      vertex -23.2873 8.364 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.0441 7.37843 -16.5
+      vertex -23.9943 8.29144 -16.5
+      vertex -23.6988 7.5251 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.5899 8.07378 -16.5
+      vertex -24.0441 7.37843 -16.5
+      vertex -24.3233 7.13399 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.0743 7.711 -16.5
+      vertex -24.3233 7.13399 -16.5
+      vertex -24.5288 6.80399 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.0441 7.37843 -16.5
+      vertex -24.5899 8.07378 -16.5
+      vertex -23.9943 8.29144 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.6467 6.62521 -16.5
+      vertex -24.5288 6.80399 -16.5
+      vertex -24.6521 6.39932 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.7183 5.92 -16.5
+      vertex -24.6521 6.39932 -16.5
+      vertex -24.6933 5.92 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.5863 5.00356 -16.5
+      vertex -24.5297 5.00266 -16.5
+      vertex -25.4213 4.605 -16.5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -24.6521 6.39932 -16.5
+      vertex -25.7183 5.92 -16.5
+      vertex -25.6467 6.62521 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.5297 5.00266 -16.5
+      vertex -25.5863 5.00356 -16.5
+      vertex -24.6524 5.42032 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -25.6853 5.44188 -16.5
+      vertex -24.6524 5.42032 -16.5
+      vertex -25.5863 5.00356 -16.5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -24.5288 6.80399 -16.5
+      vertex -25.6467 6.62521 -16.5
+      vertex -25.432 7.22221 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.6524 5.42032 -16.5
+      vertex -25.6853 5.44188 -16.5
+      vertex -24.6933 5.92 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.5288 6.80399 -16.5
+      vertex -25.432 7.22221 -16.5
+      vertex -25.0743 7.711 -16.5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -24.6933 5.92 -16.5
+      vertex -25.6853 5.44188 -16.5
+      vertex -25.7183 5.92 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -24.3233 7.13399 -16.5
+      vertex -25.0743 7.711 -16.5
+      vertex -24.5899 8.07378 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.584 3.5 -16.5
+      vertex -2.57899 5.549 -16.5
+      vertex -2.57899 3.5 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.584 8.29999 -16.5
+      vertex -2.57899 5.549 -16.5
+      vertex -3.584 3.5 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.57899 5.549 -16.5
+      vertex -3.584 8.29999 -16.5
+      vertex -2.57899 6.37999 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.57899 6.37999 -16.5
+      vertex -3.584 8.29999 -16.5
+      vertex -2.57899 8.29999 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.57899 5.549 -16.5
+      vertex -0.472992 6.37999 -16.5
+      vertex -0.472992 5.549 -16.5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.472992 6.37999 -16.5
+      vertex -2.57899 5.549 -16.5
+      vertex -2.57899 6.37999 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.472992 5.549 -16.5
+      vertex 0.532013 3.5 -16.5
+      vertex -0.472992 3.5 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.532013 3.5 -16.5
+      vertex -0.472992 5.549 -16.5
+      vertex 0.532013 8.29999 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.472992 6.37999 -16.5
+      vertex 0.532013 8.29999 -16.5
+      vertex -0.472992 5.549 -16.5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 0.532013 8.29999 -16.5
+      vertex -0.472992 6.37999 -16.5
+      vertex -0.472992 8.29999 -16.5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.48091 4.728 -16.5
+      vertex -6.95291 5.48399 -16.5
+      vertex -5.68692 5.48399 -16.5
     endloop
   endfacet
   facet normal 0 -0 -1
     outer loop
-      vertex 14.366 8.29423 7
-      vertex 17.4226 1 7
-      vertex 13.5 7.79423 7
+      vertex -6.95291 5.48399 -16.5
+      vertex -5.48091 4.728 -16.5
+      vertex -7.15892 4.728 -16.5
     endloop
   endfacet
-  facet normal -0.5 0.866025 0
+  facet normal 0 0 -1
     outer loop
-      vertex 14.366 8.29423 7
-      vertex 13.5 7.79423 15.5
-      vertex 14.366 8.29423 15.5
+      vertex -5.48091 4.728 -16.5
+      vertex -4.08591 3.5 -16.5
+      vertex -5.09091 3.5 -16.5
     endloop
   endfacet
-  facet normal -0.5 0.866025 0
+  facet normal 0 0 -1
     outer loop
-      vertex 13.5 7.79423 15.5
-      vertex 14.366 8.29423 7
-      vertex 13.5 7.79423 7
+      vertex -5.68692 5.48399 -16.5
+      vertex -4.08591 3.5 -16.5
+      vertex -5.48091 4.728 -16.5
     endloop
   endfacet
-  facet normal 0 -0.939693 0.34202
+  facet normal 0 0 -1
     outer loop
-      vertex 27.0868 0 12.6105
-      vertex 33.2952 1.59766 17
-      vertex -1.95552 1.59766 17
+      vertex -5.68692 5.48399 -16.5
+      vertex -5.72592 8.29999 -16.5
+      vertex -4.08591 3.5 -16.5
     endloop
   endfacet
-  facet normal 0 -0.939693 0.34202
+  facet normal 0 0 -1
     outer loop
-      vertex 27.0868 0 12.6105
-      vertex -1.95552 1.59766 17
-      vertex -0.357864 0 12.6105
+      vertex -6.14514 6.94577 -16.5
+      vertex -5.72592 8.29999 -16.5
+      vertex -5.68692 5.48399 -16.5
     endloop
   endfacet
-  facet normal 1.06407e-008 -0.939693 0.34202
+  facet normal 0 0 -1
     outer loop
-      vertex 32.9 -0.0229473 12.5474
-      vertex 33.2952 1.59766 17
-      vertex 27.0868 0 12.6105
+      vertex -6.22391 7.20699 -16.5
+      vertex -5.72592 8.29999 -16.5
+      vertex -6.14514 6.94577 -16.5
     endloop
   endfacet
-  facet normal 0 -0.939693 0.342019
+  facet normal 0 0 -1
     outer loop
-      vertex 32.9 -0.0229473 12.5474
-      vertex 27.0868 0 12.6105
-      vertex 27.1 -0.0229473 12.5474
+      vertex -6.31792 7.56099 -16.5
+      vertex -5.72592 8.29999 -16.5
+      vertex -6.22391 7.20699 -16.5
     endloop
   endfacet
-  facet normal -2.96371e-007 -0.939693 0.34202
+  facet normal 0 0 -1
     outer loop
-      vertex 33.2952 1.59766 17
-      vertex 32.9 -0.0229473 12.5474
-      vertex 33.7373 1.4273 16.5319
+      vertex -6.91092 8.29999 -16.5
+      vertex -6.38391 7.32599 -16.5
+      vertex -6.51791 6.86299 -16.5
     endloop
   endfacet
-  facet normal 0.612373 0.353554 0.707106
+  facet normal 0 0 -1
     outer loop
-      vertex 35.8 5 16.5165
-      vertex 35.2506 4.98453 17
-      vertex 35.7911 4.98453 16.5319
+      vertex -6.31792 7.56099 -16.5
+      vertex -6.91092 8.29999 -16.5
+      vertex -5.72592 8.29999 -16.5
     endloop
   endfacet
-  facet normal 0.612373 0.353553 0.707106
+  facet normal 0 0 -1
     outer loop
-      vertex 32.9 10.0229 16.5165
-      vertex 35.2506 4.98453 17
-      vertex 35.8 5 16.5165
+      vertex -6.38391 7.32599 -16.5
+      vertex -6.91092 8.29999 -16.5
+      vertex -6.31792 7.56099 -16.5
     endloop
   endfacet
-  facet normal 0.612372 0.353553 0.707107
+  facet normal 0 0 -1
     outer loop
-      vertex 35.2506 4.98453 17
-      vertex 32.9 10.0229 16.5165
-      vertex 32.3417 10.0229 17
+      vertex -6.95291 5.48399 -16.5
+      vertex -6.91092 8.29999 -16.5
+      vertex -6.51791 6.86299 -16.5
     endloop
   endfacet
-  facet normal 0.612373 -0.353553 0.707106
+  facet normal 0 0 -1
     outer loop
-      vertex 35.2506 4.98453 17
-      vertex 33.7373 1.4273 16.5319
-      vertex 35.7911 4.98453 16.5319
+      vertex -8.54492 3.5 -16.5
+      vertex -6.95291 5.48399 -16.5
+      vertex -7.15892 4.728 -16.5
     endloop
   endfacet
-  facet normal 0.612371 -0.353553 0.707109
+  facet normal 0 0 -1
     outer loop
-      vertex 33.7373 1.4273 16.5319
-      vertex 35.2506 4.98453 17
-      vertex 33.2952 1.59766 17
+      vertex -8.54492 3.5 -16.5
+      vertex -7.15892 4.728 -16.5
+      vertex -7.54991 3.5 -16.5
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal -0 0 -1
     outer loop
-      vertex -3 5 -4.92893
-      vertex -0.5 5 0
-      vertex -3 5 0
+      vertex -6.95291 5.48399 -16.5
+      vertex -8.54492 3.5 -16.5
+      vertex -6.91092 8.29999 -16.5
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal 0 0 -1
     outer loop
-      vertex -0.5 5 0
-      vertex -3 5 -4.92893
-      vertex -0.5 5 -4.92893
+      vertex -11.5018 5.29199 -16.5
+      vertex -10.3128 6.07199 -16.5
+      vertex -10.3128 5.29199 -16.5
     endloop
   endfacet
-  facet normal 1 0 0
+  facet normal 0 0 -1
     outer loop
-      vertex -0.5 10 0
-      vertex -0.5 6.07107 -6
-      vertex -0.5 10 -6
+      vertex -11.5018 5.29199 -16.5
+      vertex -11.6368 6.07199 -16.5
+      vertex -10.3128 6.07199 -16.5
     endloop
   endfacet
-  facet normal 1 0 0
+  facet normal 0 0 -1
     outer loop
-      vertex -0.5 5 -4.92893
-      vertex -0.5 10 0
-      vertex -0.5 5 0
+      vertex -11.5018 5.29199 -16.5
+      vertex -11.8978 6.09366 -16.5
+      vertex -11.6368 6.07199 -16.5
     endloop
   endfacet
-  facet normal 1 0 0
+  facet normal 0 0 -1
     outer loop
-      vertex -0.5 10 0
-      vertex -0.5 5 -4.92893
-      vertex -0.5 6.07107 -6
+      vertex -12.4488 5.48599 -16.5
+      vertex -11.8978 6.09366 -16.5
+      vertex -11.5018 5.29199 -16.5
     endloop
   endfacet
-  facet normal 0 -0.707107 -0.707107
+  facet normal -0 0 -1
     outer loop
-      vertex -3 6.07107 -6
-      vertex -0.5 5 -4.92893
-      vertex -3 5 -4.92893
+      vertex -11.8978 6.09366 -16.5
+      vertex -12.4488 5.48599 -16.5
+      vertex -12.1128 6.15866 -16.5
     endloop
   endfacet
-  facet normal 0 -0.707107 -0.707107
+  facet normal -0 0 -1
     outer loop
-      vertex -0.5 5 -4.92893
-      vertex -3 6.07107 -6
-      vertex -0.5 6.07107 -6
+      vertex -12.1128 6.15866 -16.5
+      vertex -12.4488 5.48599 -16.5
+      vertex -12.2818 6.267 -16.5
     endloop
   endfacet
-  facet normal -0.707107 -0.707107 8.42937e-008
+  facet normal 0 0 -1
     outer loop
-      vertex -3 2.64214 16
-      vertex -1.95552 1.59766 17
-      vertex -2 1.64214 17
+      vertex -12.7524 5.5921 -16.5
+      vertex -12.2818 6.267 -16.5
+      vertex -12.4488 5.48599 -16.5
     endloop
   endfacet
-  facet normal -0.707107 -0.707107 -6.69851e-009
+  facet normal 0 0 -1
     outer loop
-      vertex -3 2.64214 16
-      vertex -0.357864 0 12.6105
-      vertex -1.95552 1.59766 17
+      vertex -12.6208 3.5 -16.5
+      vertex -12.4488 5.48599 -16.5
+      vertex -11.5018 5.29199 -16.5
     endloop
   endfacet
-  facet normal -0.707107 -0.707107 0
+  facet normal 0 0 -1
     outer loop
-      vertex -3 2.64214 0
-      vertex -0.357864 0 12.6105
-      vertex -3 2.64214 16
+      vertex -12.4488 5.48599 -16.5
+      vertex -12.6208 3.5 -16.5
+      vertex -13.7518 3.5 -16.5
     endloop
   endfacet
-  facet normal -0.707107 -0.707107 -0
+  facet normal 0 0 -1
     outer loop
-      vertex -0.357864 0 12.6105
-      vertex -3 2.64214 0
-      vertex -0.357864 0 0
+      vertex -10.3128 5.29199 -16.5
+      vertex -9.30783 3.5 -16.5
+      vertex -10.3128 3.5 -16.5
     endloop
   endfacet
-  facet normal -0.707107 0 0.707107
+  facet normal 0 0 -1
     outer loop
-      vertex -3 2.64214 16
-      vertex -2 10 17
-      vertex -3 9 16
+      vertex -10.3128 6.07199 -16.5
+      vertex -9.30783 3.5 -16.5
+      vertex -10.3128 5.29199 -16.5
     endloop
   endfacet
-  facet normal -0.707107 0 0.707107
+  facet normal 0 0 -1
     outer loop
-      vertex -2 10 17
-      vertex -3 2.64214 16
-      vertex -2 1.64214 17
+      vertex -9.30783 3.5 -16.5
+      vertex -10.3128 6.07199 -16.5
+      vertex -9.30783 8.29999 -16.5
     endloop
   endfacet
-  facet normal -0.707107 0.707107 0
+  facet normal 0 0 -1
     outer loop
-      vertex -3 9 16
-      vertex -2 10 -6
-      vertex -3 9 -6
+      vertex -10.3128 7.51999 -16.5
+      vertex -9.30783 8.29999 -16.5
+      vertex -10.3128 6.07199 -16.5
     endloop
   endfacet
-  facet normal -0.707107 0.707107 0
+  facet normal 0 0 -1
     outer loop
-      vertex -2 10 -6
-      vertex -3 9 16
-      vertex -2 10 17
+      vertex -11.7148 8.29999 -16.5
+      vertex -10.3128 7.51999 -16.5
+      vertex -11.6098 7.51999 -16.5
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 24.6521 6.39932 16.5
-      vertex 25.7183 5.92 16.5
-      vertex 25.6467 6.62521 16.5
+      vertex -10.3128 7.51999 -16.5
+      vertex -11.7148 8.29999 -16.5
+      vertex -9.30783 8.29999 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 25.7183 5.92 16.5
-      vertex 24.6933 5.92 16.5
-      vertex 25.6853 5.44188 16.5
+      vertex -12.1054 7.44144 -16.5
+      vertex -11.7148 8.29999 -16.5
+      vertex -11.6098 7.51999 -16.5
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 24.5288 6.80399 16.5
-      vertex 25.6467 6.62521 16.5
-      vertex 25.432 7.22221 16.5
+      vertex -12.1054 7.44144 -16.5
+      vertex -12.2452 8.25844 -16.5
+      vertex -11.7148 8.29999 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 24.6524 5.42032 16.5
-      vertex 25.6853 5.44188 16.5
-      vertex 24.6933 5.92 16.5
+      vertex -12.6882 8.13377 -16.5
+      vertex -12.1054 7.44144 -16.5
+      vertex -12.4027 7.20576 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 25.6853 5.44188 16.5
-      vertex 24.6524 5.42032 16.5
-      vertex 25.5863 5.00356 16.5
+      vertex -13.4607 7.28333 -16.5
+      vertex -12.4027 7.20576 -16.5
+      vertex -12.5018 6.81299 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 24.5288 6.80399 16.5
-      vertex 25.432 7.22221 16.5
-      vertex 25.0743 7.711 16.5
+      vertex -12.1054 7.44144 -16.5
+      vertex -12.6882 8.13377 -16.5
+      vertex -12.2452 8.25844 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 24.5297 5.00266 16.5
-      vertex 25.5863 5.00356 16.5
-      vertex 24.6524 5.42032 16.5
+      vertex -13.0111 5.75444 -16.5
+      vertex -12.2818 6.267 -16.5
+      vertex -12.7524 5.5921 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0 0 -1
     outer loop
-      vertex 25.5863 5.00356 16.5
-      vertex 24.5297 5.00266 16.5
-      vertex 25.4213 4.605 16.5
+      vertex -12.2818 6.267 -16.5
+      vertex -13.0111 5.75444 -16.5
+      vertex -12.4041 6.41432 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 25.7183 5.92 16.5
-      vertex 24.6521 6.39932 16.5
-      vertex 24.6933 5.92 16.5
+      vertex -13.2248 5.97299 -16.5
+      vertex -12.4041 6.41432 -16.5
+      vertex -13.0111 5.75444 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0 0 -1
     outer loop
-      vertex 24.3233 7.13399 16.5
-      vertex 25.0743 7.711 16.5
-      vertex 24.5899 8.07378 16.5
+      vertex -12.4041 6.41432 -16.5
+      vertex -13.2248 5.97299 -16.5
+      vertex -12.4774 6.59633 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 25.6467 6.62521 16.5
-      vertex 24.5288 6.80399 16.5
-      vertex 24.6521 6.39932 16.5
+      vertex -13.3848 6.23566 -16.5
+      vertex -12.4774 6.59633 -16.5
+      vertex -13.2248 5.97299 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 -0 -1
     outer loop
-      vertex 25.0743 7.711 16.5
-      vertex 24.3233 7.13399 16.5
-      vertex 24.5288 6.80399 16.5
+      vertex -13.4607 7.28333 -16.5
+      vertex -12.5018 6.81299 -16.5
+      vertex -13.5128 6.853 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 24.5899 8.07378 16.5
-      vertex 24.0441 7.37843 16.5
-      vertex 24.3233 7.13399 16.5
+      vertex -13.4808 6.52899 -16.5
+      vertex -12.4774 6.59633 -16.5
+      vertex -13.3848 6.23566 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 23.9943 8.29144 16.5
-      vertex 24.0441 7.37843 16.5
-      vertex 24.5899 8.07378 16.5
+      vertex -12.4027 7.20576 -16.5
+      vertex -13.4607 7.28333 -16.5
+      vertex -13.3044 7.64099 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0 0 -1
     outer loop
-      vertex 23.9943 8.29144 16.5
-      vertex 23.6988 7.5251 16.5
-      vertex 24.0441 7.37843 16.5
+      vertex -12.4774 6.59633 -16.5
+      vertex -13.4808 6.52899 -16.5
+      vertex -12.5018 6.81299 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 23.2873 8.364 16.5
-      vertex 23.6988 7.5251 16.5
-      vertex 23.9943 8.29144 16.5
+      vertex -12.4027 7.20576 -16.5
+      vertex -13.0438 7.92599 -16.5
+      vertex -12.6882 8.13377 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0 0 -1
     outer loop
-      vertex 23.2873 8.364 16.5
-      vertex 23.2873 7.57399 16.5
-      vertex 23.6988 7.5251 16.5
+      vertex -12.5018 6.81299 -16.5
+      vertex -13.4808 6.52899 -16.5
+      vertex -13.5128 6.853 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 23.2873 8.364 16.5
-      vertex 22.87 7.52544 16.5
-      vertex 23.2873 7.57399 16.5
+      vertex -12.4027 7.20576 -16.5
+      vertex -13.3044 7.64099 -16.5
+      vertex -13.0438 7.92599 -16.5
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 22.5804 8.29222 16.5
-      vertex 22.87 7.52544 16.5
-      vertex 23.2873 8.364 16.5
+      vertex -15.2268 3.5 -16.5
+      vertex -14.2218 8.29999 -16.5
+      vertex -14.2218 3.5 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0 0 -1
     outer loop
-      vertex 22.5804 8.29222 16.5
-      vertex 22.521 7.37978 16.5
-      vertex 22.87 7.52544 16.5
+      vertex -14.2218 8.29999 -16.5
+      vertex -15.2268 3.5 -16.5
+      vertex -15.2268 8.29999 -16.5
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 21.985 8.07687 16.5
-      vertex 22.521 7.37978 16.5
-      vertex 22.5804 8.29222 16.5
+      vertex -17.1253 5.63699 -16.5
+      vertex -18.2853 6.37999 -16.5
+      vertex -17.1253 6.37999 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 22.521 7.37978 16.5
-      vertex 21.985 8.07687 16.5
-      vertex 22.2403 7.13699 16.5
+      vertex -18.4083 5.63699 -16.5
+      vertex -18.2853 6.37999 -16.5
+      vertex -17.1253 5.63699 -16.5
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 21.5013 7.71799 16.5
-      vertex 22.2403 7.13699 16.5
-      vertex 21.985 8.07687 16.5
+      vertex -18.4083 5.63699 -16.5
+      vertex -18.5452 6.39621 -16.5
+      vertex -18.2853 6.37999 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 22.2403 7.13699 16.5
-      vertex 21.5013 7.71799 16.5
-      vertex 22.0353 6.808 16.5
+      vertex -19.1923 6.03899 -16.5
+      vertex -18.5452 6.39621 -16.5
+      vertex -18.4083 5.63699 -16.5
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal -0 0 -1
     outer loop
-      vertex 21.1446 7.23155 16.5
-      vertex 22.0353 6.808 16.5
-      vertex 21.5013 7.71799 16.5
+      vertex -18.5452 6.39621 -16.5
+      vertex -19.1923 6.03899 -16.5
+      vertex -18.7529 6.44489 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 20.9306 6.63222 16.5
-      vertex 22.0353 6.808 16.5
-      vertex 21.1446 7.23155 16.5
+      vertex -19.1923 6.03899 -16.5
+      vertex -18.4083 5.63699 -16.5
+      vertex -18.9494 5.56122 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0 0 -1
     outer loop
-      vertex 22.0353 6.808 16.5
-      vertex 20.9306 6.63222 16.5
-      vertex 21.9123 6.40233 16.5
+      vertex -18.7529 6.44489 -16.5
+      vertex -19.1923 6.03899 -16.5
+      vertex -18.9083 6.52599 -16.5
     endloop
   endfacet
-  facet normal 0 -0 1
+  facet normal -0 0 -1
     outer loop
-      vertex 20.9307 5.20444 16.5
-      vertex 21.8713 5.92 16.5
-      vertex 20.8593 5.92 16.5
+      vertex -18.9083 6.52599 -16.5
+      vertex -19.1923 6.03899 -16.5
+      vertex -19.0161 6.64011 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 20.8593 5.92 16.5
-      vertex 21.9123 6.40233 16.5
-      vertex 20.9306 6.63222 16.5
+      vertex -19.4764 6.12444 -16.5
+      vertex -19.0161 6.64011 -16.5
+      vertex -19.1923 6.03899 -16.5
     endloop
   endfacet
-  facet normal 0 -0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 21.145 4.59776 16.5
-      vertex 21.8713 5.92 16.5
-      vertex 20.9307 5.20444 16.5
+      vertex -19.7074 6.25011 -16.5
+      vertex -19.0161 6.64011 -16.5
+      vertex -19.4764 6.12444 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 21.9123 6.40233 16.5
-      vertex 20.8593 5.92 16.5
-      vertex 21.8713 5.92 16.5
+      vertex -19.2741 5.33388 -16.5
+      vertex -19.1923 6.03899 -16.5
+      vertex -18.9494 5.56122 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 21.8713 5.92 16.5
-      vertex 21.145 4.59776 16.5
-      vertex 21.5023 4.09999 16.5
+      vertex -20.0833 5.67 -16.5
+      vertex -19.2741 5.33388 -16.5
+      vertex -19.3823 4.95499 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 25.4213 4.605 16.5
-      vertex 24.5297 5.00266 16.5
-      vertex 25.1948 4.25655 16.5
+      vertex -19.2741 5.33388 -16.5
+      vertex -19.5513 5.96733 -16.5
+      vertex -19.1923 6.03899 -16.5
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal -0 0 -1
     outer loop
-      vertex 24.3253 4.66699 16.5
-      vertex 25.1948 4.25655 16.5
-      vertex 24.5297 5.00266 16.5
+      vertex -19.2823 4.56122 -16.5
+      vertex -20.1712 4.133 -16.5
+      vertex -19.3573 4.73854 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 25.1948 4.25655 16.5
-      vertex 24.3253 4.66699 16.5
-      vertex 24.9115 3.96721 16.5
+      vertex -20.3356 4.47198 -16.5
+      vertex -19.3573 4.73854 -16.5
+      vertex -20.1712 4.133 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 -0 -1
     outer loop
-      vertex 24.9115 3.96721 16.5
-      vertex 24.3253 4.66699 16.5
-      vertex 24.5713 3.737 16.5
+      vertex -20.3562 5.18466 -16.5
+      vertex -19.3823 4.95499 -16.5
+      vertex -20.3903 4.877 -16.5
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 24.046 4.422 16.5
-      vertex 24.5713 3.737 16.5
-      vertex 24.3253 4.66699 16.5
+      vertex -19.2741 5.33388 -16.5
+      vertex -19.8483 5.84433 -16.5
+      vertex -19.5513 5.96733 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 24.5713 3.737 16.5
-      vertex 24.046 4.422 16.5
-      vertex 24.182 3.56976 16.5
+      vertex -20.3903 4.877 -16.5
+      vertex -19.3573 4.73854 -16.5
+      vertex -20.3356 4.47198 -16.5
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 -0 -1
     outer loop
-      vertex 23.6977 4.27499 16.5
-      vertex 24.182 3.56976 16.5
-      vertex 24.046 4.422 16.5
+      vertex -20.2539 5.44899 -16.5
+      vertex -19.3823 4.95499 -16.5
+      vertex -20.3562 5.18466 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 24.182 3.56976 16.5
-      vertex 23.6977 4.27499 16.5
-      vertex 23.7517 3.46945 16.5
+      vertex -19.3573 4.73854 -16.5
+      vertex -20.3903 4.877 -16.5
+      vertex -19.3823 4.95499 -16.5
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 23.2803 4.226 16.5
-      vertex 23.7517 3.46945 16.5
-      vertex 23.6977 4.27499 16.5
+      vertex -19.2741 5.33388 -16.5
+      vertex -20.0833 5.67 -16.5
+      vertex -19.8483 5.84433 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 23.2803 4.226 16.5
-      vertex 23.2803 3.436 16.5
-      vertex 23.7517 3.46945 16.5
+      vertex -19.3823 4.95499 -16.5
+      vertex -20.2539 5.44899 -16.5
+      vertex -20.0833 5.67 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 22.8755 4.27632 16.5
-      vertex 23.2803 3.436 16.5
-      vertex 23.2803 4.226 16.5
+      vertex -17.1253 5.63699 -16.5
+      vertex -16.1203 3.5 -16.5
+      vertex -17.1253 4.24599 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 22.8755 4.27632 16.5
-      vertex 22.5787 3.50977 16.5
-      vertex 23.2803 3.436 16.5
+      vertex -18.5303 3.5 -16.5
+      vertex -17.1253 4.24599 -16.5
+      vertex -16.1203 3.5 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0 0 -1
     outer loop
-      vertex 22.5318 4.42732 16.5
-      vertex 22.5787 3.50977 16.5
-      vertex 22.8755 4.27632 16.5
+      vertex -17.1253 4.24599 -16.5
+      vertex -18.5303 3.5 -16.5
+      vertex -18.4463 4.24599 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 21.986 3.73111 16.5
-      vertex 22.5318 4.42732 16.5
-      vertex 22.2493 4.67899 16.5
+      vertex -18.5303 3.5 -16.5
+      vertex -18.7418 4.26566 -16.5
+      vertex -18.4463 4.24599 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 21.5023 4.09999 16.5
-      vertex 22.2493 4.67899 16.5
-      vertex 22.0393 5.01866 16.5
+      vertex -19.0711 3.53999 -16.5
+      vertex -18.7418 4.26566 -16.5
+      vertex -18.5303 3.5 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0 0 -1
     outer loop
-      vertex 22.5318 4.42732 16.5
-      vertex 21.986 3.73111 16.5
-      vertex 22.5787 3.50977 16.5
+      vertex -18.7418 4.26566 -16.5
+      vertex -19.0711 3.53999 -16.5
+      vertex -18.9788 4.32466 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 21.5023 4.09999 16.5
-      vertex 22.0393 5.01866 16.5
-      vertex 21.9133 5.43233 16.5
+      vertex -19.5268 3.65999 -16.5
+      vertex -18.9788 4.32466 -16.5
+      vertex -19.0711 3.53999 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0 0 -1
     outer loop
-      vertex 21.5023 4.09999 16.5
-      vertex 21.9133 5.43233 16.5
-      vertex 21.8713 5.92 16.5
+      vertex -18.9788 4.32466 -16.5
+      vertex -19.5268 3.65999 -16.5
+      vertex -19.1573 4.42299 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 22.2493 4.67899 16.5
-      vertex 21.5023 4.09999 16.5
-      vertex 21.986 3.73111 16.5
+      vertex -19.8973 3.85999 -16.5
+      vertex -19.1573 4.42299 -16.5
+      vertex -19.5268 3.65999 -16.5
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex -0.532013 8.29999 16.5
-      vertex 0.472992 6.37999 16.5
-      vertex 0.472992 8.29999 16.5
+      vertex -20.1712 4.133 -16.5
+      vertex -19.2823 4.56122 -16.5
+      vertex -19.8973 3.85999 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0 0 -1
     outer loop
-      vertex 0.472992 6.37999 16.5
-      vertex -0.532013 8.29999 16.5
-      vertex 0.472992 5.549 16.5
+      vertex -19.1573 4.42299 -16.5
+      vertex -19.8973 3.85999 -16.5
+      vertex -19.2823 4.56122 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex -0.532013 3.5 16.5
-      vertex 0.472992 5.549 16.5
-      vertex -0.532013 8.29999 16.5
+      vertex -16.1203 3.5 -16.5
+      vertex -17.1253 5.63699 -16.5
+      vertex -16.1203 8.29999 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 0.472992 5.549 16.5
-      vertex -0.532013 3.5 16.5
-      vertex 0.472992 3.5 16.5
+      vertex -17.1253 6.37999 -16.5
+      vertex -16.1203 8.29999 -16.5
+      vertex -17.1253 5.63699 -16.5
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 0.472992 6.37999 16.5
-      vertex 2.57899 5.549 16.5
-      vertex 2.57899 6.37999 16.5
+      vertex -17.1253 7.55399 -16.5
+      vertex -16.1203 8.29999 -16.5
+      vertex -17.1253 6.37999 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 2.57899 5.549 16.5
-      vertex 0.472992 6.37999 16.5
-      vertex 0.472992 5.549 16.5
+      vertex -18.3253 8.29999 -16.5
+      vertex -17.1253 7.55399 -16.5
+      vertex -18.2783 7.55399 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 2.57899 6.37999 16.5
-      vertex 3.584 8.29999 16.5
-      vertex 2.57899 8.29999 16.5
+      vertex -17.1253 7.55399 -16.5
+      vertex -18.3253 8.29999 -16.5
+      vertex -16.1203 8.29999 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 2.57899 5.549 16.5
-      vertex 3.584 8.29999 16.5
-      vertex 2.57899 6.37999 16.5
+      vertex -18.5286 7.53899 -16.5
+      vertex -18.3253 8.29999 -16.5
+      vertex -18.2783 7.55399 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 3.584 8.29999 16.5
-      vertex 2.57899 5.549 16.5
-      vertex 3.584 3.5 16.5
+      vertex -18.8657 8.26633 -16.5
+      vertex -18.5286 7.53899 -16.5
+      vertex -18.7339 7.49399 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 3.584 3.5 16.5
-      vertex 2.57899 5.549 16.5
-      vertex 2.57899 3.5 16.5
+      vertex -18.5286 7.53899 -16.5
+      vertex -18.8657 8.26633 -16.5
+      vertex -18.3253 8.29999 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 8.54492 3.5 16.5
-      vertex 7.15892 4.728 16.5
-      vertex 7.54991 3.5 16.5
+      vertex -18.8943 7.41899 -16.5
+      vertex -18.8657 8.26633 -16.5
+      vertex -18.7339 7.49399 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 8.54492 3.5 16.5
-      vertex 6.95291 5.48399 16.5
-      vertex 7.15892 4.728 16.5
+      vertex -19.3107 8.16533 -16.5
+      vertex -18.8943 7.41899 -16.5
+      vertex -19.0099 7.30899 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 6.91092 8.29999 16.5
-      vertex 6.95291 5.48399 16.5
-      vertex 8.54492 3.5 16.5
+      vertex -19.912 7.76288 -16.5
+      vertex -19.0099 7.30899 -16.5
+      vertex -19.0792 7.15765 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 6.91092 8.29999 16.5
-      vertex 6.51791 6.86299 16.5
-      vertex 6.95291 5.48399 16.5
+      vertex -18.8943 7.41899 -16.5
+      vertex -19.3107 8.16533 -16.5
+      vertex -18.8657 8.26633 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 6.91092 8.29999 16.5
-      vertex 6.38391 7.32599 16.5
-      vertex 6.51791 6.86299 16.5
+      vertex -20.1133 7.10199 -16.5
+      vertex -19.0792 7.15765 -16.5
+      vertex -19.1023 6.965 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0 0 -1
     outer loop
-      vertex 6.91092 8.29999 16.5
-      vertex 6.31792 7.56099 16.5
-      vertex 6.38391 7.32599 16.5
+      vertex -19.0161 6.64011 -16.5
+      vertex -19.7074 6.25011 -16.5
+      vertex -19.0808 6.78644 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 5.72592 8.29999 16.5
-      vertex 6.22391 7.20699 16.5
-      vertex 6.31792 7.56099 16.5
+      vertex -19.8853 6.41599 -16.5
+      vertex -19.0808 6.78644 -16.5
+      vertex -19.7074 6.25011 -16.5
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 5.72592 8.29999 16.5
-      vertex 6.31792 7.56099 16.5
-      vertex 6.91092 8.29999 16.5
+      vertex -19.0099 7.30899 -16.5
+      vertex -19.6603 7.99699 -16.5
+      vertex -19.3107 8.16533 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 6.22391 7.20699 16.5
-      vertex 5.72592 8.29999 16.5
-      vertex 6.14514 6.94577 16.5
+      vertex -20.012 6.61665 -16.5
+      vertex -19.0808 6.78644 -16.5
+      vertex -19.8853 6.41599 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0 0 -1
     outer loop
-      vertex 5.72592 8.29999 16.5
-      vertex 5.68692 5.48399 16.5
-      vertex 6.14514 6.94577 16.5
+      vertex -19.0808 6.78644 -16.5
+      vertex -20.012 6.61665 -16.5
+      vertex -19.1023 6.965 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0 0 -1
     outer loop
-      vertex 4.08591 3.5 16.5
-      vertex 5.68692 5.48399 16.5
-      vertex 5.72592 8.29999 16.5
+      vertex -19.0792 7.15765 -16.5
+      vertex -20.1133 7.10199 -16.5
+      vertex -20.063 7.46455 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 5.68692 5.48399 16.5
-      vertex 4.08591 3.5 16.5
-      vertex 5.48091 4.728 16.5
+      vertex -19.1023 6.965 -16.5
+      vertex -20.012 6.61665 -16.5
+      vertex -20.088 6.84532 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 5.48091 4.728 16.5
-      vertex 4.08591 3.5 16.5
-      vertex 5.09091 3.5 16.5
+      vertex -19.0792 7.15765 -16.5
+      vertex -20.063 7.46455 -16.5
+      vertex -19.912 7.76288 -16.5
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal -0 0 -1
     outer loop
-      vertex 5.68692 5.48399 16.5
-      vertex 7.15892 4.728 16.5
-      vertex 6.95291 5.48399 16.5
+      vertex -19.1023 6.965 -16.5
+      vertex -20.088 6.84532 -16.5
+      vertex -20.1133 7.10199 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0 0 -1
     outer loop
-      vertex 7.15892 4.728 16.5
-      vertex 5.68692 5.48399 16.5
-      vertex 5.48091 4.728 16.5
+      vertex -19.0099 7.30899 -16.5
+      vertex -19.912 7.76288 -16.5
+      vertex -19.6603 7.99699 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.227018 0.973891 -0
     outer loop
-      vertex 13.4607 7.28333 16.5
-      vertex 12.4027 7.20576 16.5
-      vertex 12.5018 6.81299 16.5
+      vertex -23.7517 3.46945 -17
+      vertex -24.182 3.56976 -16.5
+      vertex -23.7517 3.46945 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.227018 0.973891 0
     outer loop
-      vertex 12.1054 7.44144 16.5
-      vertex 12.6882 8.13377 16.5
-      vertex 12.2452 8.25844 16.5
+      vertex -24.182 3.56976 -16.5
+      vertex -23.7517 3.46945 -17
+      vertex -24.182 3.56976 -17
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.394771 0.918779 -0
     outer loop
-      vertex 12.6882 8.13377 16.5
-      vertex 12.1054 7.44144 16.5
-      vertex 12.4027 7.20576 16.5
+      vertex -24.182 3.56976 -17
+      vertex -24.5713 3.737 -16.5
+      vertex -24.182 3.56976 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.394771 0.918779 0
     outer loop
-      vertex 11.7148 8.29999 16.5
-      vertex 12.1054 7.44144 16.5
-      vertex 12.2452 8.25844 16.5
+      vertex -24.5713 3.737 -16.5
+      vertex -24.182 3.56976 -17
+      vertex -24.5713 3.737 -17
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.560405 0.828219 -0
     outer loop
-      vertex 11.7148 8.29999 16.5
-      vertex 11.6098 7.51999 16.5
-      vertex 12.1054 7.44144 16.5
+      vertex -24.5713 3.737 -17
+      vertex -24.9115 3.96721 -16.5
+      vertex -24.5713 3.737 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.560405 0.828219 0
     outer loop
-      vertex 11.7148 8.29999 16.5
-      vertex 10.3128 7.51999 16.5
-      vertex 11.6098 7.51999 16.5
+      vertex -24.9115 3.96721 -16.5
+      vertex -24.5713 3.737 -17
+      vertex -24.9115 3.96721 -17
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.714491 0.699645 0
     outer loop
-      vertex 9.30783 8.29999 16.5
-      vertex 10.3128 6.07199 16.5
-      vertex 10.3128 7.51999 16.5
+      vertex -24.9115 3.96721 -16.5
+      vertex -25.1948 4.25655 -17
+      vertex -25.1948 4.25655 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.714491 0.699645 0
     outer loop
-      vertex 9.30783 3.5 16.5
-      vertex 10.3128 6.07199 16.5
-      vertex 9.30783 8.29999 16.5
+      vertex -25.1948 4.25655 -17
+      vertex -24.9115 3.96721 -16.5
+      vertex -24.9115 3.96721 -17
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0.838484 0.544926 0
     outer loop
-      vertex 9.30783 8.29999 16.5
-      vertex 10.3128 7.51999 16.5
-      vertex 11.7148 8.29999 16.5
+      vertex -25.1948 4.25655 -16.5
+      vertex -25.4213 4.605 -17
+      vertex -25.4213 4.605 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.838484 0.544926 0
     outer loop
-      vertex 10.3128 6.07199 16.5
-      vertex 9.30783 3.5 16.5
-      vertex 10.3128 5.29199 16.5
+      vertex -25.4213 4.605 -17
+      vertex -25.1948 4.25655 -16.5
+      vertex -25.1948 4.25655 -17
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.923958 0.382494 0
     outer loop
-      vertex 10.3128 5.29199 16.5
-      vertex 9.30783 3.5 16.5
-      vertex 10.3128 3.5 16.5
+      vertex -25.4213 4.605 -16.5
+      vertex -25.5863 5.00356 -17
+      vertex -25.5863 5.00356 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.923958 0.382494 0
     outer loop
-      vertex 12.5018 6.81299 16.5
-      vertex 13.5128 6.853 16.5
-      vertex 13.4607 7.28333 16.5
+      vertex -25.5863 5.00356 -17
+      vertex -25.4213 4.605 -16.5
+      vertex -25.4213 4.605 -17
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.97543 0.220309 0
     outer loop
-      vertex 13.5128 6.853 16.5
-      vertex 12.5018 6.81299 16.5
-      vertex 13.4808 6.52899 16.5
+      vertex -25.5863 5.00356 -16.5
+      vertex -25.6853 5.44188 -17
+      vertex -25.6853 5.44188 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.97543 0.220309 0
     outer loop
-      vertex 12.4027 7.20576 16.5
-      vertex 13.4607 7.28333 16.5
-      vertex 13.3044 7.64099 16.5
+      vertex -25.6853 5.44188 -17
+      vertex -25.5863 5.00356 -16.5
+      vertex -25.5863 5.00356 -17
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0.997626 0.0688666 0
     outer loop
-      vertex 12.4774 6.59633 16.5
-      vertex 13.4808 6.52899 16.5
-      vertex 12.5018 6.81299 16.5
+      vertex -25.6853 5.44188 -16.5
+      vertex -25.7183 5.92 -17
+      vertex -25.7183 5.92 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.997626 0.0688666 0
     outer loop
-      vertex 12.4027 7.20576 16.5
-      vertex 13.3044 7.64099 16.5
-      vertex 13.0438 7.92599 16.5
+      vertex -25.7183 5.92 -17
+      vertex -25.6853 5.44188 -16.5
+      vertex -25.6853 5.44188 -17
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.994891 -0.100959 0
     outer loop
-      vertex 13.4808 6.52899 16.5
-      vertex 12.4774 6.59633 16.5
-      vertex 13.3848 6.23566 16.5
+      vertex -25.7183 5.92 -16.5
+      vertex -25.6467 6.62521 -17
+      vertex -25.6467 6.62521 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.994891 -0.100959 0
     outer loop
-      vertex 13.3848 6.23566 16.5
-      vertex 12.4774 6.59633 16.5
-      vertex 13.2248 5.97299 16.5
+      vertex -25.6467 6.62521 -17
+      vertex -25.7183 5.92 -16.5
+      vertex -25.7183 5.92 -17
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.941018 -0.338357 0
     outer loop
-      vertex 12.4027 7.20576 16.5
-      vertex 13.0438 7.92599 16.5
-      vertex 12.6882 8.13377 16.5
+      vertex -25.6467 6.62521 -16.5
+      vertex -25.432 7.22221 -17
+      vertex -25.432 7.22221 -16.5
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0.941018 -0.338357 0
     outer loop
-      vertex 12.4041 6.41432 16.5
-      vertex 13.2248 5.97299 16.5
-      vertex 12.4774 6.59633 16.5
+      vertex -25.432 7.22221 -17
+      vertex -25.6467 6.62521 -16.5
+      vertex -25.6467 6.62521 -17
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.806932 -0.590645 0
     outer loop
-      vertex 13.2248 5.97299 16.5
-      vertex 12.4041 6.41432 16.5
-      vertex 13.0111 5.75444 16.5
+      vertex -25.432 7.22221 -16.5
+      vertex -25.0743 7.711 -17
+      vertex -25.0743 7.711 -16.5
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0.806932 -0.590645 0
     outer loop
-      vertex 12.2818 6.267 16.5
-      vertex 13.0111 5.75444 16.5
-      vertex 12.4041 6.41432 16.5
+      vertex -25.0743 7.711 -17
+      vertex -25.432 7.22221 -16.5
+      vertex -25.432 7.22221 -17
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.599492 -0.800381 0
     outer loop
-      vertex 13.0111 5.75444 16.5
-      vertex 12.2818 6.267 16.5
-      vertex 12.7524 5.5921 16.5
+      vertex -25.0743 7.711 -17
+      vertex -24.5899 8.07378 -16.5
+      vertex -25.0743 7.711 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.599492 -0.800381 0
     outer loop
-      vertex 12.4488 5.48599 16.5
-      vertex 12.6208 3.5 16.5
-      vertex 13.7518 3.5 16.5
+      vertex -24.5899 8.07378 -16.5
+      vertex -25.0743 7.711 -17
+      vertex -24.5899 8.07378 -17
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.343224 -0.939253 0
     outer loop
-      vertex 12.7524 5.5921 16.5
-      vertex 12.2818 6.267 16.5
-      vertex 12.4488 5.48599 16.5
+      vertex -24.5899 8.07378 -17
+      vertex -23.9943 8.29144 -16.5
+      vertex -24.5899 8.07378 -16.5
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0.343224 -0.939253 0
     outer loop
-      vertex 12.1128 6.15866 16.5
-      vertex 12.4488 5.48599 16.5
-      vertex 12.2818 6.267 16.5
+      vertex -23.9943 8.29144 -16.5
+      vertex -24.5899 8.07378 -17
+      vertex -23.9943 8.29144 -17
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0.102088 -0.994775 0
     outer loop
-      vertex 11.8978 6.09366 16.5
-      vertex 12.4488 5.48599 16.5
-      vertex 12.1128 6.15866 16.5
+      vertex -23.9943 8.29144 -17
+      vertex -23.2873 8.364 -16.5
+      vertex -23.9943 8.29144 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.102088 -0.994775 0
     outer loop
-      vertex 12.4488 5.48599 16.5
-      vertex 11.8978 6.09366 16.5
-      vertex 11.5018 5.29199 16.5
+      vertex -23.2873 8.364 -16.5
+      vertex -23.9943 8.29144 -17
+      vertex -23.2873 8.364 -17
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.10102 -0.994884 0
     outer loop
-      vertex 11.5018 5.29199 16.5
-      vertex 11.8978 6.09366 16.5
-      vertex 11.6368 6.07199 16.5
+      vertex -23.2873 8.364 -17
+      vertex -22.5804 8.29222 -16.5
+      vertex -23.2873 8.364 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.10102 -0.994884 -0
     outer loop
-      vertex 12.4488 5.48599 16.5
-      vertex 11.5018 5.29199 16.5
-      vertex 12.6208 3.5 16.5
+      vertex -22.5804 8.29222 -16.5
+      vertex -23.2873 8.364 -17
+      vertex -22.5804 8.29222 -17
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal -0.340154 -0.94037 0
     outer loop
-      vertex 10.3128 6.07199 16.5
-      vertex 11.5018 5.29199 16.5
-      vertex 11.6368 6.07199 16.5
+      vertex -22.5804 8.29222 -17
+      vertex -21.985 8.07687 -16.5
+      vertex -22.5804 8.29222 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.340154 -0.94037 -0
     outer loop
-      vertex 11.5018 5.29199 16.5
-      vertex 10.3128 6.07199 16.5
-      vertex 10.3128 5.29199 16.5
+      vertex -21.985 8.07687 -16.5
+      vertex -22.5804 8.29222 -17
+      vertex -21.985 8.07687 -17
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal -0.595797 -0.803135 0
     outer loop
-      vertex 14.2218 8.29999 16.5
-      vertex 15.2268 3.5 16.5
-      vertex 15.2268 8.29999 16.5
+      vertex -21.985 8.07687 -17
+      vertex -21.5013 7.71799 -16.5
+      vertex -21.985 8.07687 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.595797 -0.803135 -0
     outer loop
-      vertex 15.2268 3.5 16.5
-      vertex 14.2218 8.29999 16.5
-      vertex 14.2218 3.5 16.5
+      vertex -21.5013 7.71799 -16.5
+      vertex -21.985 8.07687 -17
+      vertex -21.5013 7.71799 -17
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal -0.806452 -0.591299 0
     outer loop
-      vertex 19.0792 7.15765 16.5
-      vertex 20.1133 7.10199 16.5
-      vertex 20.063 7.46455 16.5
+      vertex -21.1446 7.23155 -17
+      vertex -21.5013 7.71799 -16.5
+      vertex -21.5013 7.71799 -17
     endloop
   endfacet
-  facet normal 0 -0 1
+  facet normal -0.806452 -0.591299 0
     outer loop
-      vertex 19.1023 6.965 16.5
-      vertex 20.1133 7.10199 16.5
-      vertex 19.0792 7.15765 16.5
+      vertex -21.5013 7.71799 -16.5
+      vertex -21.1446 7.23155 -17
+      vertex -21.1446 7.23155 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.941764 -0.336276 0
     outer loop
-      vertex 19.0792 7.15765 16.5
-      vertex 20.063 7.46455 16.5
-      vertex 19.912 7.76288 16.5
+      vertex -20.9306 6.63222 -17
+      vertex -21.1446 7.23155 -16.5
+      vertex -21.1446 7.23155 -17
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.941764 -0.336276 0
     outer loop
-      vertex 20.1133 7.10199 16.5
-      vertex 19.1023 6.965 16.5
-      vertex 20.088 6.84532 16.5
+      vertex -21.1446 7.23155 -16.5
+      vertex -20.9306 6.63222 -17
+      vertex -20.9306 6.63222 -16.5
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal -0.995022 -0.0996599 0
     outer loop
-      vertex 19.0808 6.78644 16.5
-      vertex 20.012 6.61665 16.5
-      vertex 19.1023 6.965 16.5
+      vertex -20.8593 5.92 -17
+      vertex -20.9306 6.63222 -16.5
+      vertex -20.9306 6.63222 -17
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.995022 -0.0996599 0
     outer loop
-      vertex 19.0099 7.30899 16.5
-      vertex 19.912 7.76288 16.5
-      vertex 19.6603 7.99699 16.5
+      vertex -20.9306 6.63222 -16.5
+      vertex -20.8593 5.92 -17
+      vertex -20.8593 5.92 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.995051 0.0993672 0
     outer loop
-      vertex 20.012 6.61665 16.5
-      vertex 19.0808 6.78644 16.5
-      vertex 19.8853 6.41599 16.5
+      vertex -20.9307 5.20444 -17
+      vertex -20.8593 5.92 -16.5
+      vertex -20.8593 5.92 -17
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.995051 0.0993672 0
     outer loop
-      vertex 19.0099 7.30899 16.5
-      vertex 19.6603 7.99699 16.5
-      vertex 19.3107 8.16533 16.5
+      vertex -20.8593 5.92 -16.5
+      vertex -20.9307 5.20444 -17
+      vertex -20.9307 5.20444 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.94289 0.333103 0
     outer loop
-      vertex 19.8853 6.41599 16.5
-      vertex 19.0808 6.78644 16.5
-      vertex 19.7074 6.25011 16.5
+      vertex -21.145 4.59776 -17
+      vertex -20.9307 5.20444 -16.5
+      vertex -20.9307 5.20444 -17
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal -0.94289 0.333103 0
     outer loop
-      vertex 19.0161 6.64011 16.5
-      vertex 19.7074 6.25011 16.5
-      vertex 19.0808 6.78644 16.5
+      vertex -20.9307 5.20444 -16.5
+      vertex -21.145 4.59776 -17
+      vertex -21.145 4.59776 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.812441 0.583044 0
     outer loop
-      vertex 20.088 6.84532 16.5
-      vertex 19.1023 6.965 16.5
-      vertex 20.012 6.61665 16.5
+      vertex -21.5023 4.09999 -17
+      vertex -21.145 4.59776 -16.5
+      vertex -21.145 4.59776 -17
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.812441 0.583044 0
     outer loop
-      vertex 19.912 7.76288 16.5
-      vertex 19.0099 7.30899 16.5
-      vertex 19.0792 7.15765 16.5
+      vertex -21.145 4.59776 -16.5
+      vertex -21.5023 4.09999 -17
+      vertex -21.5023 4.09999 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.606342 0.795204 0
     outer loop
-      vertex 19.3107 8.16533 16.5
-      vertex 18.8943 7.41899 16.5
-      vertex 19.0099 7.30899 16.5
+      vertex -21.5023 4.09999 -17
+      vertex -21.986 3.73111 -16.5
+      vertex -21.5023 4.09999 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.606342 0.795204 0
     outer loop
-      vertex 18.8657 8.26633 16.5
-      vertex 18.8943 7.41899 16.5
-      vertex 19.3107 8.16533 16.5
+      vertex -21.986 3.73111 -16.5
+      vertex -21.5023 4.09999 -17
+      vertex -21.986 3.73111 -17
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.349868 0.936799 0
     outer loop
-      vertex 18.8657 8.26633 16.5
-      vertex 18.7339 7.49399 16.5
-      vertex 18.8943 7.41899 16.5
+      vertex -21.986 3.73111 -17
+      vertex -22.5787 3.50977 -16.5
+      vertex -21.986 3.73111 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.349868 0.936799 0
     outer loop
-      vertex 18.8657 8.26633 16.5
-      vertex 18.5286 7.53899 16.5
-      vertex 18.7339 7.49399 16.5
+      vertex -22.5787 3.50977 -16.5
+      vertex -21.986 3.73111 -17
+      vertex -22.5787 3.50977 -17
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.104563 0.994518 0
     outer loop
-      vertex 18.3253 8.29999 16.5
-      vertex 18.5286 7.53899 16.5
-      vertex 18.8657 8.26633 16.5
+      vertex -22.5787 3.50977 -17
+      vertex -23.2803 3.436 -16.5
+      vertex -22.5787 3.50977 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.104563 0.994518 0
     outer loop
-      vertex 18.3253 8.29999 16.5
-      vertex 18.2783 7.55399 16.5
-      vertex 18.5286 7.53899 16.5
+      vertex -23.2803 3.436 -16.5
+      vertex -22.5787 3.50977 -17
+      vertex -23.2803 3.436 -17
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.0707675 0.997493 -0
     outer loop
-      vertex 18.3253 8.29999 16.5
-      vertex 17.1253 7.55399 16.5
-      vertex 18.2783 7.55399 16.5
+      vertex -23.2803 3.436 -17
+      vertex -23.7517 3.46945 -16.5
+      vertex -23.2803 3.436 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.0707675 0.997493 0
     outer loop
-      vertex 16.1203 8.29999 16.5
-      vertex 17.1253 6.37999 16.5
-      vertex 17.1253 7.55399 16.5
+      vertex -23.7517 3.46945 -16.5
+      vertex -23.2803 3.436 -17
+      vertex -23.7517 3.46945 -17
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.402273 -0.91552 0
     outer loop
-      vertex 17.1253 6.37999 16.5
-      vertex 16.1203 8.29999 16.5
-      vertex 17.1253 5.63699 16.5
+      vertex -22.8755 4.27632 -17
+      vertex -22.5318 4.42732 -16.5
+      vertex -22.8755 4.27632 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.402273 -0.91552 0
     outer loop
-      vertex 16.1203 3.5 16.5
-      vertex 17.1253 5.63699 16.5
-      vertex 16.1203 8.29999 16.5
+      vertex -22.5318 4.42732 -16.5
+      vertex -22.8755 4.27632 -17
+      vertex -22.5318 4.42732 -17
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0.665097 -0.746757 0
     outer loop
-      vertex 16.1203 8.29999 16.5
-      vertex 17.1253 7.55399 16.5
-      vertex 18.3253 8.29999 16.5
+      vertex -22.5318 4.42732 -17
+      vertex -22.2493 4.67899 -16.5
+      vertex -22.5318 4.42732 -16.5
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0.665097 -0.746757 0
     outer loop
-      vertex 19.3823 4.95499 16.5
-      vertex 20.3903 4.877 16.5
-      vertex 20.3562 5.18466 16.5
+      vertex -22.2493 4.67899 -16.5
+      vertex -22.5318 4.42732 -17
+      vertex -22.2493 4.67899 -17
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.850583 -0.52584 0
     outer loop
-      vertex 19.3823 4.95499 16.5
-      vertex 20.3562 5.18466 16.5
-      vertex 20.2539 5.44899 16.5
+      vertex -22.2493 4.67899 -16.5
+      vertex -22.0393 5.01866 -17
+      vertex -22.0393 5.01866 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.850583 -0.52584 0
     outer loop
-      vertex 19.3573 4.73854 16.5
-      vertex 20.3903 4.877 16.5
-      vertex 19.3823 4.95499 16.5
+      vertex -22.0393 5.01866 -17
+      vertex -22.2493 4.67899 -16.5
+      vertex -22.2493 4.67899 -17
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.956604 -0.291392 0
     outer loop
-      vertex 19.3823 4.95499 16.5
-      vertex 20.2539 5.44899 16.5
-      vertex 20.0833 5.67 16.5
+      vertex -22.0393 5.01866 -16.5
+      vertex -21.9133 5.43233 -17
+      vertex -21.9133 5.43233 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.956604 -0.291392 0
     outer loop
-      vertex 20.3903 4.877 16.5
-      vertex 19.3573 4.73854 16.5
-      vertex 20.3356 4.47198 16.5
+      vertex -21.9133 5.43233 -17
+      vertex -22.0393 5.01866 -16.5
+      vertex -22.0393 5.01866 -17
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.996313 -0.0857902 0
     outer loop
-      vertex 19.2741 5.33388 16.5
-      vertex 20.0833 5.67 16.5
-      vertex 19.8483 5.84433 16.5
+      vertex -21.9133 5.43233 -16.5
+      vertex -21.8713 5.92 -17
+      vertex -21.8713 5.92 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.996313 -0.0857902 0
     outer loop
-      vertex 19.2741 5.33388 16.5
-      vertex 19.8483 5.84433 16.5
-      vertex 19.5513 5.96733 16.5
+      vertex -21.8713 5.92 -17
+      vertex -21.9133 5.43233 -16.5
+      vertex -21.9133 5.43233 -17
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.996407 0.0846993 0
     outer loop
-      vertex 20.3356 4.47198 16.5
-      vertex 19.3573 4.73854 16.5
-      vertex 20.1712 4.133 16.5
+      vertex -21.8713 5.92 -16.5
+      vertex -21.9123 6.40233 -17
+      vertex -21.9123 6.40233 -16.5
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0.996407 0.0846993 0
     outer loop
-      vertex 19.2823 4.56122 16.5
-      vertex 20.1712 4.133 16.5
-      vertex 19.3573 4.73854 16.5
+      vertex -21.9123 6.40233 -17
+      vertex -21.8713 5.92 -16.5
+      vertex -21.8713 5.92 -17
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.956978 0.29016 0
     outer loop
-      vertex 20.0833 5.67 16.5
-      vertex 19.2741 5.33388 16.5
-      vertex 19.3823 4.95499 16.5
+      vertex -21.9123 6.40233 -16.5
+      vertex -22.0353 6.808 -17
+      vertex -22.0353 6.808 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.956978 0.29016 0
     outer loop
-      vertex 19.1923 6.03899 16.5
-      vertex 19.2741 5.33388 16.5
-      vertex 19.5513 5.96733 16.5
+      vertex -22.0353 6.808 -17
+      vertex -21.9123 6.40233 -16.5
+      vertex -21.9123 6.40233 -17
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.848716 0.528849 0
     outer loop
-      vertex 19.7074 6.25011 16.5
-      vertex 19.0161 6.64011 16.5
-      vertex 19.4764 6.12444 16.5
+      vertex -22.0353 6.808 -16.5
+      vertex -22.2403 7.13699 -17
+      vertex -22.2403 7.13699 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.848716 0.528849 0
     outer loop
-      vertex 19.4764 6.12444 16.5
-      vertex 19.0161 6.64011 16.5
-      vertex 19.1923 6.03899 16.5
+      vertex -22.2403 7.13699 -17
+      vertex -22.0353 6.808 -16.5
+      vertex -22.0353 6.808 -17
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0.654072 0.756432 -0
     outer loop
-      vertex 18.9083 6.52599 16.5
-      vertex 19.1923 6.03899 16.5
-      vertex 19.0161 6.64011 16.5
+      vertex -22.2403 7.13699 -17
+      vertex -22.521 7.37978 -16.5
+      vertex -22.2403 7.13699 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.654072 0.756432 0
     outer loop
-      vertex 19.1923 6.03899 16.5
-      vertex 18.9494 5.56122 16.5
-      vertex 19.2741 5.33388 16.5
+      vertex -22.521 7.37978 -16.5
+      vertex -22.2403 7.13699 -17
+      vertex -22.521 7.37978 -17
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0.385165 0.922848 -0
     outer loop
-      vertex 18.7529 6.44489 16.5
-      vertex 19.1923 6.03899 16.5
-      vertex 18.9083 6.52599 16.5
+      vertex -22.521 7.37978 -17
+      vertex -22.87 7.52544 -16.5
+      vertex -22.521 7.37978 -16.5
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal 0.385165 0.922848 0
     outer loop
-      vertex 18.5452 6.39621 16.5
-      vertex 19.1923 6.03899 16.5
-      vertex 18.7529 6.44489 16.5
+      vertex -22.87 7.52544 -16.5
+      vertex -22.521 7.37978 -17
+      vertex -22.87 7.52544 -17
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.115593 0.993297 -0
     outer loop
-      vertex 19.1923 6.03899 16.5
-      vertex 18.5452 6.39621 16.5
-      vertex 18.9494 5.56122 16.5
+      vertex -22.87 7.52544 -17
+      vertex -23.2873 7.57399 -16.5
+      vertex -22.87 7.52544 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal 0.115593 0.993297 0
     outer loop
-      vertex 18.5452 6.39621 16.5
-      vertex 18.4083 5.63699 16.5
-      vertex 18.9494 5.56122 16.5
+      vertex -23.2873 7.57399 -16.5
+      vertex -22.87 7.52544 -17
+      vertex -23.2873 7.57399 -17
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal -0.117965 0.993018 0
     outer loop
-      vertex 18.2853 6.37999 16.5
-      vertex 18.4083 5.63699 16.5
-      vertex 18.5452 6.39621 16.5
+      vertex -23.2873 7.57399 -17
+      vertex -23.6988 7.5251 -16.5
+      vertex -23.2873 7.57399 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.117965 0.993018 0
     outer loop
-      vertex 17.1253 5.63699 16.5
-      vertex 18.2853 6.37999 16.5
-      vertex 17.1253 6.37999 16.5
+      vertex -23.6988 7.5251 -16.5
+      vertex -23.2873 7.57399 -17
+      vertex -23.6988 7.5251 -17
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.390913 0.920428 0
     outer loop
-      vertex 18.2853 6.37999 16.5
-      vertex 17.1253 5.63699 16.5
-      vertex 18.4083 5.63699 16.5
+      vertex -23.6988 7.5251 -17
+      vertex -24.0441 7.37843 -16.5
+      vertex -23.6988 7.5251 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.390913 0.920428 0
     outer loop
-      vertex 20.1712 4.133 16.5
-      vertex 19.2823 4.56122 16.5
-      vertex 19.8973 3.85999 16.5
+      vertex -24.0441 7.37843 -16.5
+      vertex -23.6988 7.5251 -17
+      vertex -24.0441 7.37843 -17
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal -0.658842 0.752281 0
     outer loop
-      vertex 19.1573 4.42299 16.5
-      vertex 19.8973 3.85999 16.5
-      vertex 19.2823 4.56122 16.5
+      vertex -24.0441 7.37843 -17
+      vertex -24.3233 7.13399 -16.5
+      vertex -24.0441 7.37843 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.658842 0.752281 0
     outer loop
-      vertex 19.8973 3.85999 16.5
-      vertex 19.1573 4.42299 16.5
-      vertex 19.5268 3.65999 16.5
+      vertex -24.3233 7.13399 -16.5
+      vertex -24.0441 7.37843 -17
+      vertex -24.3233 7.13399 -17
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal -0.848807 0.528704 0
     outer loop
-      vertex 18.9788 4.32466 16.5
-      vertex 19.5268 3.65999 16.5
-      vertex 19.1573 4.42299 16.5
+      vertex -24.5288 6.80399 -17
+      vertex -24.3233 7.13399 -16.5
+      vertex -24.3233 7.13399 -17
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.848807 0.528704 0
     outer loop
-      vertex 19.5268 3.65999 16.5
-      vertex 18.9788 4.32466 16.5
-      vertex 19.0711 3.53999 16.5
+      vertex -24.3233 7.13399 -16.5
+      vertex -24.5288 6.80399 -17
+      vertex -24.5288 6.80399 -16.5
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal -0.956556 0.291548 0
     outer loop
-      vertex 18.7418 4.26566 16.5
-      vertex 19.0711 3.53999 16.5
-      vertex 18.9788 4.32466 16.5
+      vertex -24.6521 6.39932 -17
+      vertex -24.5288 6.80399 -16.5
+      vertex -24.5288 6.80399 -17
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.956556 0.291548 0
     outer loop
-      vertex 18.7418 4.26566 16.5
-      vertex 18.5303 3.5 16.5
-      vertex 19.0711 3.53999 16.5
+      vertex -24.5288 6.80399 -16.5
+      vertex -24.6521 6.39932 -17
+      vertex -24.6521 6.39932 -16.5
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal -0.996343 0.085447 0
     outer loop
-      vertex 18.4463 4.24599 16.5
-      vertex 18.5303 3.5 16.5
-      vertex 18.7418 4.26566 16.5
+      vertex -24.6933 5.92 -17
+      vertex -24.6521 6.39932 -16.5
+      vertex -24.6521 6.39932 -17
     endloop
   endfacet
-  facet normal -0 0 1
+  facet normal -0.996343 0.085447 0
     outer loop
-      vertex 17.1253 4.24599 16.5
-      vertex 18.5303 3.5 16.5
-      vertex 18.4463 4.24599 16.5
+      vertex -24.6521 6.39932 -16.5
+      vertex -24.6933 5.92 -17
+      vertex -24.6933 5.92 -16.5
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.99667 -0.0815366 0
     outer loop
-      vertex 17.1253 4.24599 16.5
-      vertex 16.1203 3.5 16.5
-      vertex 18.5303 3.5 16.5
+      vertex -24.6524 5.42032 -17
+      vertex -24.6933 5.92 -16.5
+      vertex -24.6933 5.92 -17
     endloop
   endfacet
-  facet normal 0 0 1
+  facet normal -0.99667 -0.0815366 0
     outer loop
-      vertex 17.1253 5.63699 16.5
-      vertex 16.1203 3.5 16.5
-      vertex 17.1253 4.24599 16.5
+      vertex -24.6933 5.92 -16.5
+      vertex -24.6524 5.42032 -17
+      vertex -24.6524 5.42032 -16.5
     endloop
   endfacet
-  facet normal -0.227018 0.973891 0
+  facet normal -0.959475 -0.281792 0
     outer loop
-      vertex 24.182 3.56976 16.5
-      vertex 23.7517 3.46945 17
-      vertex 24.182 3.56976 17
+      vertex -24.5297 5.00266 -17
+      vertex -24.6524 5.42032 -16.5
+      vertex -24.6524 5.42032 -17
     endloop
   endfacet
-  facet normal -0.227018 0.973891 0
+  facet normal -0.959475 -0.281792 0
     outer loop
-      vertex 23.7517 3.46945 17
-      vertex 24.182 3.56976 16.5
-      vertex 23.7517 3.46945 16.5
+      vertex -24.6524 5.42032 -16.5
+      vertex -24.5297 5.00266 -17
+      vertex -24.5297 5.00266 -16.5
     endloop
   endfacet
-  facet normal -0.394771 0.918779 0
+  facet normal -0.854045 -0.520199 0
     outer loop
-      vertex 24.5713 3.737 16.5
-      vertex 24.182 3.56976 17
-      vertex 24.5713 3.737 17
+      vertex -24.3253 4.66699 -17
+      vertex -24.5297 5.00266 -16.5
+      vertex -24.5297 5.00266 -17
     endloop
   endfacet
-  facet normal -0.394771 0.918779 0
+  facet normal -0.854045 -0.520199 0
     outer loop
-      vertex 24.182 3.56976 17
-      vertex 24.5713 3.737 16.5
-      vertex 24.182 3.56976 16.5
+      vertex -24.5297 5.00266 -16.5
+      vertex -24.3253 4.66699 -17
+      vertex -24.3253 4.66699 -16.5
     endloop
   endfacet
-  facet normal -0.560405 0.828219 0
+  facet normal -0.659536 -0.751673 0
     outer loop
-      vertex 24.9115 3.96721 16.5
-      vertex 24.5713 3.737 17
-      vertex 24.9115 3.96721 17
+      vertex -24.3253 4.66699 -17
+      vertex -24.046 4.422 -16.5
+      vertex -24.3253 4.66699 -16.5
     endloop
   endfacet
-  facet normal -0.560405 0.828219 0
+  facet normal -0.659536 -0.751673 -0
     outer loop
-      vertex 24.5713 3.737 17
-      vertex 24.9115 3.96721 16.5
-      vertex 24.5713 3.737 16.5
+      vertex -24.046 4.422 -16.5
+      vertex -24.3253 4.66699 -17
+      vertex -24.046 4.422 -17
     endloop
   endfacet
-  facet normal -0.714491 0.699645 0
+  facet normal -0.388818 -0.921314 0
     outer loop
-      vertex 24.9115 3.96721 16.5
-      vertex 25.1948 4.25655 17
-      vertex 25.1948 4.25655 16.5
+      vertex -24.046 4.422 -17
+      vertex -23.6977 4.27499 -16.5
+      vertex -24.046 4.422 -16.5
     endloop
   endfacet
-  facet normal -0.714491 0.699645 0
+  facet normal -0.388818 -0.921314 -0
     outer loop
-      vertex 25.1948 4.25655 17
-      vertex 24.9115 3.96721 16.5
-      vertex 24.9115 3.96721 17
+      vertex -23.6977 4.27499 -16.5
+      vertex -24.046 4.422 -17
+      vertex -23.6977 4.27499 -17
     endloop
   endfacet
-  facet normal -0.838484 0.544926 0
+  facet normal -0.11657 -0.993183 0
     outer loop
-      vertex 25.1948 4.25655 16.5
-      vertex 25.4213 4.605 17
-      vertex 25.4213 4.605 16.5
+      vertex -23.6977 4.27499 -17
+      vertex -23.2803 4.226 -16.5
+      vertex -23.6977 4.27499 -16.5
     endloop
   endfacet
-  facet normal -0.838484 0.544926 0
+  facet normal -0.11657 -0.993183 -0
     outer loop
-      vertex 25.4213 4.605 17
-      vertex 25.1948 4.25655 16.5
-      vertex 25.1948 4.25655 17
+      vertex -23.2803 4.226 -16.5
+      vertex -23.6977 4.27499 -17
+      vertex -23.2803 4.226 -17
     endloop
   endfacet
-  facet normal -0.923958 0.382494 0
+  facet normal 0.123372 -0.992361 0
     outer loop
-      vertex 25.4213 4.605 16.5
-      vertex 25.5863 5.00356 17
-      vertex 25.5863 5.00356 16.5
+      vertex -23.2803 4.226 -17
+      vertex -22.8755 4.27632 -16.5
+      vertex -23.2803 4.226 -16.5
     endloop
   endfacet
-  facet normal -0.923958 0.382494 0
+  facet normal 0.123372 -0.992361 0
     outer loop
-      vertex 25.5863 5.00356 17
-      vertex 25.4213 4.605 16.5
-      vertex 25.4213 4.605 17
-    endloop
-  endfacet
-  facet normal -0.97543 0.220309 0
-    outer loop
-      vertex 25.5863 5.00356 16.5
-      vertex 25.6853 5.44188 17
-      vertex 25.6853 5.44188 16.5
-    endloop
-  endfacet
-  facet normal -0.97543 0.220309 0
-    outer loop
-      vertex 25.6853 5.44188 17
-      vertex 25.5863 5.00356 16.5
-      vertex 25.5863 5.00356 17
-    endloop
-  endfacet
-  facet normal -0.997626 0.0688666 0
-    outer loop
-      vertex 25.6853 5.44188 16.5
-      vertex 25.7183 5.92 17
-      vertex 25.7183 5.92 16.5
-    endloop
-  endfacet
-  facet normal -0.997626 0.0688666 0
-    outer loop
-      vertex 25.7183 5.92 17
-      vertex 25.6853 5.44188 16.5
-      vertex 25.6853 5.44188 17
-    endloop
-  endfacet
-  facet normal -0.994891 -0.100959 0
-    outer loop
-      vertex 25.7183 5.92 16.5
-      vertex 25.6467 6.62521 17
-      vertex 25.6467 6.62521 16.5
-    endloop
-  endfacet
-  facet normal -0.994891 -0.100959 0
-    outer loop
-      vertex 25.6467 6.62521 17
-      vertex 25.7183 5.92 16.5
-      vertex 25.7183 5.92 17
-    endloop
-  endfacet
-  facet normal -0.941018 -0.338357 0
-    outer loop
-      vertex 25.6467 6.62521 16.5
-      vertex 25.432 7.22221 17
-      vertex 25.432 7.22221 16.5
-    endloop
-  endfacet
-  facet normal -0.941018 -0.338357 0
-    outer loop
-      vertex 25.432 7.22221 17
-      vertex 25.6467 6.62521 16.5
-      vertex 25.6467 6.62521 17
-    endloop
-  endfacet
-  facet normal -0.806932 -0.590645 0
-    outer loop
-      vertex 25.432 7.22221 16.5
-      vertex 25.0743 7.711 17
-      vertex 25.0743 7.711 16.5
-    endloop
-  endfacet
-  facet normal -0.806932 -0.590645 0
-    outer loop
-      vertex 25.0743 7.711 17
-      vertex 25.432 7.22221 16.5
-      vertex 25.432 7.22221 17
-    endloop
-  endfacet
-  facet normal -0.599492 -0.800381 0
-    outer loop
-      vertex 24.5899 8.07378 16.5
-      vertex 25.0743 7.711 17
-      vertex 24.5899 8.07378 17
-    endloop
-  endfacet
-  facet normal -0.599492 -0.800381 -0
-    outer loop
-      vertex 25.0743 7.711 17
-      vertex 24.5899 8.07378 16.5
-      vertex 25.0743 7.711 16.5
-    endloop
-  endfacet
-  facet normal -0.343224 -0.939253 0
-    outer loop
-      vertex 23.9943 8.29144 16.5
-      vertex 24.5899 8.07378 17
-      vertex 23.9943 8.29144 17
-    endloop
-  endfacet
-  facet normal -0.343224 -0.939253 -0
-    outer loop
-      vertex 24.5899 8.07378 17
-      vertex 23.9943 8.29144 16.5
-      vertex 24.5899 8.07378 16.5
-    endloop
-  endfacet
-  facet normal -0.102088 -0.994775 0
-    outer loop
-      vertex 23.2873 8.364 16.5
-      vertex 23.9943 8.29144 17
-      vertex 23.2873 8.364 17
-    endloop
-  endfacet
-  facet normal -0.102088 -0.994775 -0
-    outer loop
-      vertex 23.9943 8.29144 17
-      vertex 23.2873 8.364 16.5
-      vertex 23.9943 8.29144 16.5
-    endloop
-  endfacet
-  facet normal 0.10102 -0.994884 0
-    outer loop
-      vertex 22.5804 8.29222 16.5
-      vertex 23.2873 8.364 17
-      vertex 22.5804 8.29222 17
-    endloop
-  endfacet
-  facet normal 0.10102 -0.994884 0
-    outer loop
-      vertex 23.2873 8.364 17
-      vertex 22.5804 8.29222 16.5
-      vertex 23.2873 8.364 16.5
-    endloop
-  endfacet
-  facet normal 0.340154 -0.94037 0
-    outer loop
-      vertex 21.985 8.07687 16.5
-      vertex 22.5804 8.29222 17
-      vertex 21.985 8.07687 17
-    endloop
-  endfacet
-  facet normal 0.340154 -0.94037 0
-    outer loop
-      vertex 22.5804 8.29222 17
-      vertex 21.985 8.07687 16.5
-      vertex 22.5804 8.29222 16.5
-    endloop
-  endfacet
-  facet normal 0.595797 -0.803135 0
-    outer loop
-      vertex 21.5013 7.71799 16.5
-      vertex 21.985 8.07687 17
-      vertex 21.5013 7.71799 17
-    endloop
-  endfacet
-  facet normal 0.595797 -0.803135 0
-    outer loop
-      vertex 21.985 8.07687 17
-      vertex 21.5013 7.71799 16.5
-      vertex 21.985 8.07687 16.5
-    endloop
-  endfacet
-  facet normal 0.806452 -0.591299 0
-    outer loop
-      vertex 21.1446 7.23155 17
-      vertex 21.5013 7.71799 16.5
-      vertex 21.5013 7.71799 17
-    endloop
-  endfacet
-  facet normal 0.806452 -0.591299 0
-    outer loop
-      vertex 21.5013 7.71799 16.5
-      vertex 21.1446 7.23155 17
-      vertex 21.1446 7.23155 16.5
-    endloop
-  endfacet
-  facet normal 0.941764 -0.336276 0
-    outer loop
-      vertex 20.9306 6.63222 17
-      vertex 21.1446 7.23155 16.5
-      vertex 21.1446 7.23155 17
-    endloop
-  endfacet
-  facet normal 0.941764 -0.336276 0
-    outer loop
-      vertex 21.1446 7.23155 16.5
-      vertex 20.9306 6.63222 17
-      vertex 20.9306 6.63222 16.5
-    endloop
-  endfacet
-  facet normal 0.995022 -0.0996599 0
-    outer loop
-      vertex 20.8593 5.92 17
-      vertex 20.9306 6.63222 16.5
-      vertex 20.9306 6.63222 17
-    endloop
-  endfacet
-  facet normal 0.995022 -0.0996599 0
-    outer loop
-      vertex 20.9306 6.63222 16.5
-      vertex 20.8593 5.92 17
-      vertex 20.8593 5.92 16.5
-    endloop
-  endfacet
-  facet normal 0.995051 0.0993672 0
-    outer loop
-      vertex 20.9307 5.20444 17
-      vertex 20.8593 5.92 16.5
-      vertex 20.8593 5.92 17
-    endloop
-  endfacet
-  facet normal 0.995051 0.0993672 0
-    outer loop
-      vertex 20.8593 5.92 16.5
-      vertex 20.9307 5.20444 17
-      vertex 20.9307 5.20444 16.5
-    endloop
-  endfacet
-  facet normal 0.94289 0.333103 0
-    outer loop
-      vertex 21.145 4.59776 17
-      vertex 20.9307 5.20444 16.5
-      vertex 20.9307 5.20444 17
-    endloop
-  endfacet
-  facet normal 0.94289 0.333103 0
-    outer loop
-      vertex 20.9307 5.20444 16.5
-      vertex 21.145 4.59776 17
-      vertex 21.145 4.59776 16.5
-    endloop
-  endfacet
-  facet normal 0.812441 0.583044 0
-    outer loop
-      vertex 21.5023 4.09999 17
-      vertex 21.145 4.59776 16.5
-      vertex 21.145 4.59776 17
-    endloop
-  endfacet
-  facet normal 0.812441 0.583044 0
-    outer loop
-      vertex 21.145 4.59776 16.5
-      vertex 21.5023 4.09999 17
-      vertex 21.5023 4.09999 16.5
-    endloop
-  endfacet
-  facet normal 0.606342 0.795204 -0
-    outer loop
-      vertex 21.986 3.73111 16.5
-      vertex 21.5023 4.09999 17
-      vertex 21.986 3.73111 17
-    endloop
-  endfacet
-  facet normal 0.606342 0.795204 0
-    outer loop
-      vertex 21.5023 4.09999 17
-      vertex 21.986 3.73111 16.5
-      vertex 21.5023 4.09999 16.5
-    endloop
-  endfacet
-  facet normal 0.349868 0.936799 -0
-    outer loop
-      vertex 22.5787 3.50977 16.5
-      vertex 21.986 3.73111 17
-      vertex 22.5787 3.50977 17
-    endloop
-  endfacet
-  facet normal 0.349868 0.936799 0
-    outer loop
-      vertex 21.986 3.73111 17
-      vertex 22.5787 3.50977 16.5
-      vertex 21.986 3.73111 16.5
-    endloop
-  endfacet
-  facet normal 0.104563 0.994518 -0
-    outer loop
-      vertex 23.2803 3.436 16.5
-      vertex 22.5787 3.50977 17
-      vertex 23.2803 3.436 17
-    endloop
-  endfacet
-  facet normal 0.104563 0.994518 0
-    outer loop
-      vertex 22.5787 3.50977 17
-      vertex 23.2803 3.436 16.5
-      vertex 22.5787 3.50977 16.5
-    endloop
-  endfacet
-  facet normal -0.0707675 0.997493 0
-    outer loop
-      vertex 23.7517 3.46945 16.5
-      vertex 23.2803 3.436 17
-      vertex 23.7517 3.46945 17
-    endloop
-  endfacet
-  facet normal -0.0707675 0.997493 0
-    outer loop
-      vertex 23.2803 3.436 17
-      vertex 23.7517 3.46945 16.5
-      vertex 23.2803 3.436 16.5
-    endloop
-  endfacet
-  facet normal -0.402273 -0.91552 0
-    outer loop
-      vertex 22.5318 4.42732 16.5
-      vertex 22.8755 4.27632 17
-      vertex 22.5318 4.42732 17
-    endloop
-  endfacet
-  facet normal -0.402273 -0.91552 -0
-    outer loop
-      vertex 22.8755 4.27632 17
-      vertex 22.5318 4.42732 16.5
-      vertex 22.8755 4.27632 16.5
-    endloop
-  endfacet
-  facet normal -0.665097 -0.746757 0
-    outer loop
-      vertex 22.2493 4.67899 16.5
-      vertex 22.5318 4.42732 17
-      vertex 22.2493 4.67899 17
-    endloop
-  endfacet
-  facet normal -0.665097 -0.746757 -0
-    outer loop
-      vertex 22.5318 4.42732 17
-      vertex 22.2493 4.67899 16.5
-      vertex 22.5318 4.42732 16.5
-    endloop
-  endfacet
-  facet normal -0.850583 -0.52584 0
-    outer loop
-      vertex 22.2493 4.67899 16.5
-      vertex 22.0393 5.01866 17
-      vertex 22.0393 5.01866 16.5
-    endloop
-  endfacet
-  facet normal -0.850583 -0.52584 0
-    outer loop
-      vertex 22.0393 5.01866 17
-      vertex 22.2493 4.67899 16.5
-      vertex 22.2493 4.67899 17
-    endloop
-  endfacet
-  facet normal -0.956604 -0.291392 0
-    outer loop
-      vertex 22.0393 5.01866 16.5
-      vertex 21.9133 5.43233 17
-      vertex 21.9133 5.43233 16.5
-    endloop
-  endfacet
-  facet normal -0.956604 -0.291392 0
-    outer loop
-      vertex 21.9133 5.43233 17
-      vertex 22.0393 5.01866 16.5
-      vertex 22.0393 5.01866 17
-    endloop
-  endfacet
-  facet normal -0.996313 -0.0857902 0
-    outer loop
-      vertex 21.9133 5.43233 16.5
-      vertex 21.8713 5.92 17
-      vertex 21.8713 5.92 16.5
-    endloop
-  endfacet
-  facet normal -0.996313 -0.0857902 0
-    outer loop
-      vertex 21.8713 5.92 17
-      vertex 21.9133 5.43233 16.5
-      vertex 21.9133 5.43233 17
-    endloop
-  endfacet
-  facet normal -0.996407 0.0846993 0
-    outer loop
-      vertex 21.8713 5.92 16.5
-      vertex 21.9123 6.40233 17
-      vertex 21.9123 6.40233 16.5
-    endloop
-  endfacet
-  facet normal -0.996407 0.0846993 0
-    outer loop
-      vertex 21.9123 6.40233 17
-      vertex 21.8713 5.92 16.5
-      vertex 21.8713 5.92 17
-    endloop
-  endfacet
-  facet normal -0.956978 0.29016 0
-    outer loop
-      vertex 21.9123 6.40233 16.5
-      vertex 22.0353 6.808 17
-      vertex 22.0353 6.808 16.5
-    endloop
-  endfacet
-  facet normal -0.956978 0.29016 0
-    outer loop
-      vertex 22.0353 6.808 17
-      vertex 21.9123 6.40233 16.5
-      vertex 21.9123 6.40233 17
-    endloop
-  endfacet
-  facet normal -0.848716 0.528849 0
-    outer loop
-      vertex 22.0353 6.808 16.5
-      vertex 22.2403 7.13699 17
-      vertex 22.2403 7.13699 16.5
-    endloop
-  endfacet
-  facet normal -0.848716 0.528849 0
-    outer loop
-      vertex 22.2403 7.13699 17
-      vertex 22.0353 6.808 16.5
-      vertex 22.0353 6.808 17
-    endloop
-  endfacet
-  facet normal -0.654072 0.756432 0
-    outer loop
-      vertex 22.521 7.37978 16.5
-      vertex 22.2403 7.13699 17
-      vertex 22.521 7.37978 17
-    endloop
-  endfacet
-  facet normal -0.654072 0.756432 0
-    outer loop
-      vertex 22.2403 7.13699 17
-      vertex 22.521 7.37978 16.5
-      vertex 22.2403 7.13699 16.5
-    endloop
-  endfacet
-  facet normal -0.385165 0.922848 0
-    outer loop
-      vertex 22.87 7.52544 16.5
-      vertex 22.521 7.37978 17
-      vertex 22.87 7.52544 17
-    endloop
-  endfacet
-  facet normal -0.385165 0.922848 0
-    outer loop
-      vertex 22.521 7.37978 17
-      vertex 22.87 7.52544 16.5
-      vertex 22.521 7.37978 16.5
-    endloop
-  endfacet
-  facet normal -0.115593 0.993297 0
-    outer loop
-      vertex 23.2873 7.57399 16.5
-      vertex 22.87 7.52544 17
-      vertex 23.2873 7.57399 17
-    endloop
-  endfacet
-  facet normal -0.115593 0.993297 0
-    outer loop
-      vertex 22.87 7.52544 17
-      vertex 23.2873 7.57399 16.5
-      vertex 22.87 7.52544 16.5
-    endloop
-  endfacet
-  facet normal 0.117965 0.993018 -0
-    outer loop
-      vertex 23.6988 7.5251 16.5
-      vertex 23.2873 7.57399 17
-      vertex 23.6988 7.5251 17
-    endloop
-  endfacet
-  facet normal 0.117965 0.993018 0
-    outer loop
-      vertex 23.2873 7.57399 17
-      vertex 23.6988 7.5251 16.5
-      vertex 23.2873 7.57399 16.5
-    endloop
-  endfacet
-  facet normal 0.390913 0.920428 -0
-    outer loop
-      vertex 24.0441 7.37843 16.5
-      vertex 23.6988 7.5251 17
-      vertex 24.0441 7.37843 17
-    endloop
-  endfacet
-  facet normal 0.390913 0.920428 0
-    outer loop
-      vertex 23.6988 7.5251 17
-      vertex 24.0441 7.37843 16.5
-      vertex 23.6988 7.5251 16.5
-    endloop
-  endfacet
-  facet normal 0.658842 0.752281 -0
-    outer loop
-      vertex 24.3233 7.13399 16.5
-      vertex 24.0441 7.37843 17
-      vertex 24.3233 7.13399 17
-    endloop
-  endfacet
-  facet normal 0.658842 0.752281 0
-    outer loop
-      vertex 24.0441 7.37843 17
-      vertex 24.3233 7.13399 16.5
-      vertex 24.0441 7.37843 16.5
-    endloop
-  endfacet
-  facet normal 0.848807 0.528704 0
-    outer loop
-      vertex 24.5288 6.80399 17
-      vertex 24.3233 7.13399 16.5
-      vertex 24.3233 7.13399 17
-    endloop
-  endfacet
-  facet normal 0.848807 0.528704 0
-    outer loop
-      vertex 24.3233 7.13399 16.5
-      vertex 24.5288 6.80399 17
-      vertex 24.5288 6.80399 16.5
-    endloop
-  endfacet
-  facet normal 0.956556 0.291548 0
-    outer loop
-      vertex 24.6521 6.39932 17
-      vertex 24.5288 6.80399 16.5
-      vertex 24.5288 6.80399 17
-    endloop
-  endfacet
-  facet normal 0.956556 0.291548 0
-    outer loop
-      vertex 24.5288 6.80399 16.5
-      vertex 24.6521 6.39932 17
-      vertex 24.6521 6.39932 16.5
-    endloop
-  endfacet
-  facet normal 0.996343 0.085447 0
-    outer loop
-      vertex 24.6933 5.92 17
-      vertex 24.6521 6.39932 16.5
-      vertex 24.6521 6.39932 17
-    endloop
-  endfacet
-  facet normal 0.996343 0.085447 0
-    outer loop
-      vertex 24.6521 6.39932 16.5
-      vertex 24.6933 5.92 17
-      vertex 24.6933 5.92 16.5
-    endloop
-  endfacet
-  facet normal 0.99667 -0.0815366 0
-    outer loop
-      vertex 24.6524 5.42032 17
-      vertex 24.6933 5.92 16.5
-      vertex 24.6933 5.92 17
-    endloop
-  endfacet
-  facet normal 0.99667 -0.0815366 0
-    outer loop
-      vertex 24.6933 5.92 16.5
-      vertex 24.6524 5.42032 17
-      vertex 24.6524 5.42032 16.5
-    endloop
-  endfacet
-  facet normal 0.959475 -0.281792 0
-    outer loop
-      vertex 24.5297 5.00266 17
-      vertex 24.6524 5.42032 16.5
-      vertex 24.6524 5.42032 17
-    endloop
-  endfacet
-  facet normal 0.959475 -0.281792 0
-    outer loop
-      vertex 24.6524 5.42032 16.5
-      vertex 24.5297 5.00266 17
-      vertex 24.5297 5.00266 16.5
-    endloop
-  endfacet
-  facet normal 0.854045 -0.520199 0
-    outer loop
-      vertex 24.3253 4.66699 17
-      vertex 24.5297 5.00266 16.5
-      vertex 24.5297 5.00266 17
-    endloop
-  endfacet
-  facet normal 0.854045 -0.520199 0
-    outer loop
-      vertex 24.5297 5.00266 16.5
-      vertex 24.3253 4.66699 17
-      vertex 24.3253 4.66699 16.5
-    endloop
-  endfacet
-  facet normal 0.659536 -0.751673 0
-    outer loop
-      vertex 24.046 4.422 16.5
-      vertex 24.3253 4.66699 17
-      vertex 24.046 4.422 17
-    endloop
-  endfacet
-  facet normal 0.659536 -0.751673 0
-    outer loop
-      vertex 24.3253 4.66699 17
-      vertex 24.046 4.422 16.5
-      vertex 24.3253 4.66699 16.5
-    endloop
-  endfacet
-  facet normal 0.388818 -0.921314 0
-    outer loop
-      vertex 23.6977 4.27499 16.5
-      vertex 24.046 4.422 17
-      vertex 23.6977 4.27499 17
-    endloop
-  endfacet
-  facet normal 0.388818 -0.921314 0
-    outer loop
-      vertex 24.046 4.422 17
-      vertex 23.6977 4.27499 16.5
-      vertex 24.046 4.422 16.5
-    endloop
-  endfacet
-  facet normal 0.11657 -0.993183 0
-    outer loop
-      vertex 23.2803 4.226 16.5
-      vertex 23.6977 4.27499 17
-      vertex 23.2803 4.226 17
-    endloop
-  endfacet
-  facet normal 0.11657 -0.993183 0
-    outer loop
-      vertex 23.6977 4.27499 17
-      vertex 23.2803 4.226 16.5
-      vertex 23.6977 4.27499 16.5
-    endloop
-  endfacet
-  facet normal -0.123372 -0.992361 0
-    outer loop
-      vertex 22.8755 4.27632 16.5
-      vertex 23.2803 4.226 17
-      vertex 22.8755 4.27632 17
-    endloop
-  endfacet
-  facet normal -0.123372 -0.992361 -0
-    outer loop
-      vertex 23.2803 4.226 17
-      vertex 22.8755 4.27632 16.5
-      vertex 23.2803 4.226 16.5
+      vertex -22.8755 4.27632 -16.5
+      vertex -23.2803 4.226 -17
+      vertex -22.8755 4.27632 -17
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 2.57899 5.549 16.5
-      vertex 0.472992 5.549 17
-      vertex 2.57899 5.549 17
+      vertex -0.472992 5.549 -17
+      vertex -2.57899 5.549 -16.5
+      vertex -0.472992 5.549 -16.5
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 0.472992 5.549 17
-      vertex 2.57899 5.549 16.5
-      vertex 0.472992 5.549 16.5
+      vertex -2.57899 5.549 -16.5
+      vertex -0.472992 5.549 -17
+      vertex -2.57899 5.549 -17
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -2.57899 3.5 -17
+      vertex -2.57899 5.549 -16.5
+      vertex -2.57899 5.549 -17
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -2.57899 5.549 -16.5
+      vertex -2.57899 3.5 -17
+      vertex -2.57899 3.5 -16.5
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -2.57899 3.5 -17
+      vertex -3.584 3.5 -16.5
+      vertex -2.57899 3.5 -16.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -3.584 3.5 -16.5
+      vertex -2.57899 3.5 -17
+      vertex -3.584 3.5 -17
     endloop
   endfacet
   facet normal 1 -0 0
     outer loop
-      vertex 2.57899 3.5 17
-      vertex 2.57899 5.549 16.5
-      vertex 2.57899 5.549 17
+      vertex -3.584 3.5 -16.5
+      vertex -3.584 8.29999 -17
+      vertex -3.584 8.29999 -16.5
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
-      vertex 2.57899 5.549 16.5
-      vertex 2.57899 3.5 17
-      vertex 2.57899 3.5 16.5
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 3.584 3.5 16.5
-      vertex 2.57899 3.5 17
-      vertex 3.584 3.5 17
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 2.57899 3.5 17
-      vertex 3.584 3.5 16.5
-      vertex 2.57899 3.5 16.5
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex 3.584 3.5 16.5
-      vertex 3.584 8.29999 17
-      vertex 3.584 8.29999 16.5
-    endloop
-  endfacet
-  facet normal -1 -0 0
-    outer loop
-      vertex 3.584 8.29999 17
-      vertex 3.584 3.5 16.5
-      vertex 3.584 3.5 17
+      vertex -3.584 8.29999 -17
+      vertex -3.584 3.5 -16.5
+      vertex -3.584 3.5 -17
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
-      vertex 2.57899 8.29999 16.5
-      vertex 3.584 8.29999 17
-      vertex 2.57899 8.29999 17
+      vertex -3.584 8.29999 -17
+      vertex -2.57899 8.29999 -16.5
+      vertex -3.584 8.29999 -16.5
     endloop
   endfacet
   facet normal 0 -1 -0
     outer loop
-      vertex 3.584 8.29999 17
-      vertex 2.57899 8.29999 16.5
-      vertex 3.584 8.29999 16.5
+      vertex -2.57899 8.29999 -16.5
+      vertex -3.584 8.29999 -17
+      vertex -2.57899 8.29999 -17
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -2.57899 6.37999 -17
+      vertex -2.57899 8.29999 -16.5
+      vertex -2.57899 8.29999 -17
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -2.57899 8.29999 -16.5
+      vertex -2.57899 6.37999 -17
+      vertex -2.57899 6.37999 -16.5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -2.57899 6.37999 -17
+      vertex -0.472992 6.37999 -16.5
+      vertex -2.57899 6.37999 -16.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -0.472992 6.37999 -16.5
+      vertex -2.57899 6.37999 -17
+      vertex -0.472992 6.37999 -17
     endloop
   endfacet
   facet normal 1 -0 0
     outer loop
-      vertex 2.57899 6.37999 17
-      vertex 2.57899 8.29999 16.5
-      vertex 2.57899 8.29999 17
+      vertex -0.472992 6.37999 -16.5
+      vertex -0.472992 8.29999 -17
+      vertex -0.472992 8.29999 -16.5
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
-      vertex 2.57899 8.29999 16.5
-      vertex 2.57899 6.37999 17
-      vertex 2.57899 6.37999 16.5
+      vertex -0.472992 8.29999 -17
+      vertex -0.472992 6.37999 -16.5
+      vertex -0.472992 6.37999 -17
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
-      vertex 0.472992 6.37999 16.5
-      vertex 2.57899 6.37999 17
-      vertex 0.472992 6.37999 17
+      vertex -0.472992 8.29999 -17
+      vertex 0.532013 8.29999 -16.5
+      vertex -0.472992 8.29999 -16.5
     endloop
   endfacet
   facet normal 0 -1 -0
     outer loop
-      vertex 2.57899 6.37999 17
-      vertex 0.472992 6.37999 16.5
-      vertex 2.57899 6.37999 16.5
+      vertex 0.532013 8.29999 -16.5
+      vertex -0.472992 8.29999 -17
+      vertex 0.532013 8.29999 -17
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
-      vertex 0.472992 6.37999 16.5
-      vertex 0.472992 8.29999 17
-      vertex 0.472992 8.29999 16.5
+      vertex 0.532013 3.5 -17
+      vertex 0.532013 8.29999 -16.5
+      vertex 0.532013 8.29999 -17
     endloop
   endfacet
   facet normal -1 -0 0
     outer loop
-      vertex 0.472992 8.29999 17
-      vertex 0.472992 6.37999 16.5
-      vertex 0.472992 6.37999 17
+      vertex 0.532013 8.29999 -16.5
+      vertex 0.532013 3.5 -17
+      vertex 0.532013 3.5 -16.5
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0 1 -0
     outer loop
-      vertex -0.532013 8.29999 16.5
-      vertex 0.472992 8.29999 17
-      vertex -0.532013 8.29999 17
+      vertex 0.532013 3.5 -17
+      vertex -0.472992 3.5 -16.5
+      vertex 0.532013 3.5 -16.5
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal 0 1 0
     outer loop
-      vertex 0.472992 8.29999 17
-      vertex -0.532013 8.29999 16.5
-      vertex 0.472992 8.29999 16.5
+      vertex -0.472992 3.5 -16.5
+      vertex 0.532013 3.5 -17
+      vertex -0.472992 3.5 -17
     endloop
   endfacet
   facet normal 1 -0 0
     outer loop
-      vertex -0.532013 3.5 17
-      vertex -0.532013 8.29999 16.5
-      vertex -0.532013 8.29999 17
+      vertex -0.472992 3.5 -16.5
+      vertex -0.472992 5.549 -17
+      vertex -0.472992 5.549 -16.5
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
-      vertex -0.532013 8.29999 16.5
-      vertex -0.532013 3.5 17
-      vertex -0.532013 3.5 16.5
+      vertex -0.472992 5.549 -17
+      vertex -0.472992 3.5 -16.5
+      vertex -0.472992 3.5 -17
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 0.472992 3.5 16.5
-      vertex -0.532013 3.5 17
-      vertex 0.472992 3.5 17
+      vertex -5.48091 4.728 -17
+      vertex -7.15892 4.728 -16.5
+      vertex -5.48091 4.728 -16.5
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex -0.532013 3.5 17
-      vertex 0.472992 3.5 16.5
-      vertex -0.532013 3.5 16.5
+      vertex -7.15892 4.728 -16.5
+      vertex -5.48091 4.728 -17
+      vertex -7.15892 4.728 -17
+    endloop
+  endfacet
+  facet normal -0.952866 0.30339 0
+    outer loop
+      vertex -7.54991 3.5 -17
+      vertex -7.15892 4.728 -16.5
+      vertex -7.15892 4.728 -17
+    endloop
+  endfacet
+  facet normal -0.952866 0.30339 0
+    outer loop
+      vertex -7.15892 4.728 -16.5
+      vertex -7.54991 3.5 -17
+      vertex -7.54991 3.5 -16.5
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -7.54991 3.5 -17
+      vertex -8.54492 3.5 -16.5
+      vertex -7.54991 3.5 -16.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -8.54492 3.5 -16.5
+      vertex -7.54991 3.5 -17
+      vertex -8.54492 3.5 -17
+    endloop
+  endfacet
+  facet normal 0.946652 -0.322257 0
+    outer loop
+      vertex -8.54492 3.5 -16.5
+      vertex -6.91092 8.29999 -17
+      vertex -6.91092 8.29999 -16.5
+    endloop
+  endfacet
+  facet normal 0.946652 -0.322257 0
+    outer loop
+      vertex -6.91092 8.29999 -17
+      vertex -8.54492 3.5 -16.5
+      vertex -8.54492 3.5 -17
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -6.91092 8.29999 -17
+      vertex -5.72592 8.29999 -16.5
+      vertex -6.91092 8.29999 -16.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -5.72592 8.29999 -16.5
+      vertex -6.91092 8.29999 -17
+      vertex -5.72592 8.29999 -17
+    endloop
+  endfacet
+  facet normal -0.94629 -0.323319 0
+    outer loop
+      vertex -4.08591 3.5 -17
+      vertex -5.72592 8.29999 -16.5
+      vertex -5.72592 8.29999 -17
+    endloop
+  endfacet
+  facet normal -0.94629 -0.323319 0
+    outer loop
+      vertex -5.72592 8.29999 -16.5
+      vertex -4.08591 3.5 -17
+      vertex -4.08591 3.5 -16.5
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -4.08591 3.5 -17
+      vertex -5.09091 3.5 -16.5
+      vertex -4.08591 3.5 -16.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -5.09091 3.5 -16.5
+      vertex -4.08591 3.5 -17
+      vertex -5.09091 3.5 -17
+    endloop
+  endfacet
+  facet normal 0.953089 0.302691 0
+    outer loop
+      vertex -5.09091 3.5 -16.5
+      vertex -5.48091 4.728 -17
+      vertex -5.48091 4.728 -16.5
+    endloop
+  endfacet
+  facet normal 0.953089 0.302691 0
+    outer loop
+      vertex -5.48091 4.728 -17
+      vertex -5.09091 3.5 -16.5
+      vertex -5.09091 3.5 -17
+    endloop
+  endfacet
+  facet normal 0.954216 0.299117 0
+    outer loop
+      vertex -5.68692 5.48399 -16.5
+      vertex -6.14514 6.94577 -17
+      vertex -6.14514 6.94577 -16.5
+    endloop
+  endfacet
+  facet normal 0.954216 0.299117 0
+    outer loop
+      vertex -6.14514 6.94577 -17
+      vertex -5.68692 5.48399 -16.5
+      vertex -5.68692 5.48399 -17
+    endloop
+  endfacet
+  facet normal 0.957421 0.288697 0
+    outer loop
+      vertex -6.14514 6.94577 -16.5
+      vertex -6.22391 7.20699 -17
+      vertex -6.22391 7.20699 -16.5
+    endloop
+  endfacet
+  facet normal 0.957421 0.288697 0
+    outer loop
+      vertex -6.22391 7.20699 -17
+      vertex -6.14514 6.94577 -16.5
+      vertex -6.14514 6.94577 -17
+    endloop
+  endfacet
+  facet normal 0.966501 0.256664 0
+    outer loop
+      vertex -6.22391 7.20699 -16.5
+      vertex -6.31792 7.56099 -17
+      vertex -6.31792 7.56099 -16.5
+    endloop
+  endfacet
+  facet normal 0.966501 0.256664 0
+    outer loop
+      vertex -6.31792 7.56099 -17
+      vertex -6.22391 7.20699 -16.5
+      vertex -6.22391 7.20699 -17
+    endloop
+  endfacet
+  facet normal -0.962757 0.270367 0
+    outer loop
+      vertex -6.38391 7.32599 -17
+      vertex -6.31792 7.56099 -16.5
+      vertex -6.31792 7.56099 -17
+    endloop
+  endfacet
+  facet normal -0.962757 0.270367 0
+    outer loop
+      vertex -6.31792 7.56099 -16.5
+      vertex -6.38391 7.32599 -17
+      vertex -6.38391 7.32599 -16.5
+    endloop
+  endfacet
+  facet normal -0.960577 0.278014 0
+    outer loop
+      vertex -6.51791 6.86299 -17
+      vertex -6.38391 7.32599 -16.5
+      vertex -6.38391 7.32599 -17
+    endloop
+  endfacet
+  facet normal -0.960577 0.278014 0
+    outer loop
+      vertex -6.38391 7.32599 -16.5
+      vertex -6.51791 6.86299 -17
+      vertex -6.51791 6.86299 -16.5
+    endloop
+  endfacet
+  facet normal -0.953677 0.300832 0
+    outer loop
+      vertex -6.95291 5.48399 -17
+      vertex -6.51791 6.86299 -16.5
+      vertex -6.51791 6.86299 -17
+    endloop
+  endfacet
+  facet normal -0.953677 0.300832 0
+    outer loop
+      vertex -6.51791 6.86299 -16.5
+      vertex -6.95291 5.48399 -17
+      vertex -6.95291 5.48399 -16.5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -6.95291 5.48399 -17
+      vertex -5.68692 5.48399 -16.5
+      vertex -6.95291 5.48399 -16.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -5.68692 5.48399 -16.5
+      vertex -6.95291 5.48399 -17
+      vertex -5.68692 5.48399 -17
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -10.3128 5.29199 -17
+      vertex -11.5018 5.29199 -16.5
+      vertex -10.3128 5.29199 -16.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -11.5018 5.29199 -16.5
+      vertex -10.3128 5.29199 -17
+      vertex -11.5018 5.29199 -17
+    endloop
+  endfacet
+  facet normal -0.848209 0.529661 0
+    outer loop
+      vertex -12.6208 3.5 -17
+      vertex -11.5018 5.29199 -16.5
+      vertex -11.5018 5.29199 -17
+    endloop
+  endfacet
+  facet normal -0.848209 0.529661 0
+    outer loop
+      vertex -11.5018 5.29199 -16.5
+      vertex -12.6208 3.5 -17
+      vertex -12.6208 3.5 -16.5
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -12.6208 3.5 -17
+      vertex -13.7518 3.5 -16.5
+      vertex -12.6208 3.5 -16.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -13.7518 3.5 -16.5
+      vertex -12.6208 3.5 -17
+      vertex -13.7518 3.5 -17
+    endloop
+  endfacet
+  facet normal 0.836108 -0.548564 0
+    outer loop
+      vertex -13.7518 3.5 -16.5
+      vertex -12.4488 5.48599 -17
+      vertex -12.4488 5.48599 -16.5
+    endloop
+  endfacet
+  facet normal 0.836108 -0.548564 0
+    outer loop
+      vertex -12.4488 5.48599 -17
+      vertex -13.7518 3.5 -16.5
+      vertex -13.7518 3.5 -17
+    endloop
+  endfacet
+  facet normal 0.329974 0.94399 -0
+    outer loop
+      vertex -12.4488 5.48599 -17
+      vertex -12.7524 5.5921 -16.5
+      vertex -12.4488 5.48599 -16.5
+    endloop
+  endfacet
+  facet normal 0.329974 0.94399 0
+    outer loop
+      vertex -12.7524 5.5921 -16.5
+      vertex -12.4488 5.48599 -17
+      vertex -12.7524 5.5921 -17
+    endloop
+  endfacet
+  facet normal 0.531579 0.847009 -0
+    outer loop
+      vertex -12.7524 5.5921 -17
+      vertex -13.0111 5.75444 -16.5
+      vertex -12.7524 5.5921 -16.5
+    endloop
+  endfacet
+  facet normal 0.531579 0.847009 0
+    outer loop
+      vertex -13.0111 5.75444 -16.5
+      vertex -12.7524 5.5921 -17
+      vertex -13.0111 5.75444 -17
+    endloop
+  endfacet
+  facet normal 0.714875 0.699253 0
+    outer loop
+      vertex -13.0111 5.75444 -16.5
+      vertex -13.2248 5.97299 -17
+      vertex -13.2248 5.97299 -16.5
+    endloop
+  endfacet
+  facet normal 0.714875 0.699253 0
+    outer loop
+      vertex -13.2248 5.97299 -17
+      vertex -13.0111 5.75444 -16.5
+      vertex -13.0111 5.75444 -17
+    endloop
+  endfacet
+  facet normal 0.854024 0.520233 0
+    outer loop
+      vertex -13.2248 5.97299 -16.5
+      vertex -13.3848 6.23566 -17
+      vertex -13.3848 6.23566 -16.5
+    endloop
+  endfacet
+  facet normal 0.854024 0.520233 0
+    outer loop
+      vertex -13.3848 6.23566 -17
+      vertex -13.2248 5.97299 -16.5
+      vertex -13.2248 5.97299 -17
+    endloop
+  endfacet
+  facet normal 0.950404 0.311017 0
+    outer loop
+      vertex -13.3848 6.23566 -16.5
+      vertex -13.4808 6.52899 -17
+      vertex -13.4808 6.52899 -16.5
+    endloop
+  endfacet
+  facet normal 0.950404 0.311017 0
+    outer loop
+      vertex -13.4808 6.52899 -17
+      vertex -13.3848 6.23566 -16.5
+      vertex -13.3848 6.23566 -17
+    endloop
+  endfacet
+  facet normal 0.995159 0.0982786 0
+    outer loop
+      vertex -13.4808 6.52899 -16.5
+      vertex -13.5128 6.853 -17
+      vertex -13.5128 6.853 -16.5
+    endloop
+  endfacet
+  facet normal 0.995159 0.0982786 0
+    outer loop
+      vertex -13.5128 6.853 -17
+      vertex -13.4808 6.52899 -16.5
+      vertex -13.4808 6.52899 -17
+    endloop
+  endfacet
+  facet normal 0.992748 -0.120213 0
+    outer loop
+      vertex -13.5128 6.853 -16.5
+      vertex -13.4607 7.28333 -17
+      vertex -13.4607 7.28333 -16.5
+    endloop
+  endfacet
+  facet normal 0.992748 -0.120213 0
+    outer loop
+      vertex -13.4607 7.28333 -17
+      vertex -13.5128 6.853 -16.5
+      vertex -13.5128 6.853 -17
+    endloop
+  endfacet
+  facet normal 0.916301 -0.400491 0
+    outer loop
+      vertex -13.4607 7.28333 -16.5
+      vertex -13.3044 7.64099 -17
+      vertex -13.3044 7.64099 -16.5
+    endloop
+  endfacet
+  facet normal 0.916301 -0.400491 0
+    outer loop
+      vertex -13.3044 7.64099 -17
+      vertex -13.4607 7.28333 -16.5
+      vertex -13.4607 7.28333 -17
+    endloop
+  endfacet
+  facet normal 0.738049 -0.674747 0
+    outer loop
+      vertex -13.3044 7.64099 -16.5
+      vertex -13.0438 7.92599 -17
+      vertex -13.0438 7.92599 -16.5
+    endloop
+  endfacet
+  facet normal 0.738049 -0.674747 0
+    outer loop
+      vertex -13.0438 7.92599 -17
+      vertex -13.3044 7.64099 -16.5
+      vertex -13.3044 7.64099 -17
+    endloop
+  endfacet
+  facet normal 0.504426 -0.863455 0
+    outer loop
+      vertex -13.0438 7.92599 -17
+      vertex -12.6882 8.13377 -16.5
+      vertex -13.0438 7.92599 -16.5
+    endloop
+  endfacet
+  facet normal 0.504426 -0.863455 0
+    outer loop
+      vertex -12.6882 8.13377 -16.5
+      vertex -13.0438 7.92599 -17
+      vertex -12.6882 8.13377 -17
+    endloop
+  endfacet
+  facet normal 0.270883 -0.962612 0
+    outer loop
+      vertex -12.6882 8.13377 -17
+      vertex -12.2452 8.25844 -16.5
+      vertex -12.6882 8.13377 -16.5
+    endloop
+  endfacet
+  facet normal 0.270883 -0.962612 0
+    outer loop
+      vertex -12.2452 8.25844 -16.5
+      vertex -12.6882 8.13377 -17
+      vertex -12.2452 8.25844 -17
+    endloop
+  endfacet
+  facet normal 0.0781091 -0.996945 0
+    outer loop
+      vertex -12.2452 8.25844 -17
+      vertex -11.7148 8.29999 -16.5
+      vertex -12.2452 8.25844 -16.5
+    endloop
+  endfacet
+  facet normal 0.0781091 -0.996945 0
+    outer loop
+      vertex -11.7148 8.29999 -16.5
+      vertex -12.2452 8.25844 -17
+      vertex -11.7148 8.29999 -17
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -11.7148 8.29999 -17
+      vertex -9.30783 8.29999 -16.5
+      vertex -11.7148 8.29999 -16.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -9.30783 8.29999 -16.5
+      vertex -11.7148 8.29999 -17
+      vertex -9.30783 8.29999 -17
     endloop
   endfacet
   facet normal -1 0 0
     outer loop
-      vertex 0.472992 3.5 16.5
-      vertex 0.472992 5.549 17
-      vertex 0.472992 5.549 16.5
+      vertex -9.30783 3.5 -17
+      vertex -9.30783 8.29999 -16.5
+      vertex -9.30783 8.29999 -17
     endloop
   endfacet
   facet normal -1 -0 0
     outer loop
-      vertex 0.472992 5.549 17
-      vertex 0.472992 3.5 16.5
-      vertex 0.472992 3.5 17
+      vertex -9.30783 8.29999 -16.5
+      vertex -9.30783 3.5 -17
+      vertex -9.30783 3.5 -16.5
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 7.15892 4.728 16.5
-      vertex 5.48091 4.728 17
-      vertex 7.15892 4.728 17
+      vertex -9.30783 3.5 -17
+      vertex -10.3128 3.5 -16.5
+      vertex -9.30783 3.5 -16.5
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 5.48091 4.728 17
-      vertex 7.15892 4.728 16.5
-      vertex 5.48091 4.728 16.5
-    endloop
-  endfacet
-  facet normal 0.952866 0.30339 0
-    outer loop
-      vertex 7.54991 3.5 17
-      vertex 7.15892 4.728 16.5
-      vertex 7.15892 4.728 17
-    endloop
-  endfacet
-  facet normal 0.952866 0.30339 0
-    outer loop
-      vertex 7.15892 4.728 16.5
-      vertex 7.54991 3.5 17
-      vertex 7.54991 3.5 16.5
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 8.54492 3.5 16.5
-      vertex 7.54991 3.5 17
-      vertex 8.54492 3.5 17
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 7.54991 3.5 17
-      vertex 8.54492 3.5 16.5
-      vertex 7.54991 3.5 16.5
-    endloop
-  endfacet
-  facet normal -0.946652 -0.322257 0
-    outer loop
-      vertex 8.54492 3.5 16.5
-      vertex 6.91092 8.29999 17
-      vertex 6.91092 8.29999 16.5
-    endloop
-  endfacet
-  facet normal -0.946652 -0.322257 0
-    outer loop
-      vertex 6.91092 8.29999 17
-      vertex 8.54492 3.5 16.5
-      vertex 8.54492 3.5 17
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 5.72592 8.29999 16.5
-      vertex 6.91092 8.29999 17
-      vertex 5.72592 8.29999 17
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 6.91092 8.29999 17
-      vertex 5.72592 8.29999 16.5
-      vertex 6.91092 8.29999 16.5
-    endloop
-  endfacet
-  facet normal 0.94629 -0.323319 0
-    outer loop
-      vertex 4.08591 3.5 17
-      vertex 5.72592 8.29999 16.5
-      vertex 5.72592 8.29999 17
-    endloop
-  endfacet
-  facet normal 0.94629 -0.323319 0
-    outer loop
-      vertex 5.72592 8.29999 16.5
-      vertex 4.08591 3.5 17
-      vertex 4.08591 3.5 16.5
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 5.09091 3.5 16.5
-      vertex 4.08591 3.5 17
-      vertex 5.09091 3.5 17
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 4.08591 3.5 17
-      vertex 5.09091 3.5 16.5
-      vertex 4.08591 3.5 16.5
-    endloop
-  endfacet
-  facet normal -0.953089 0.302691 0
-    outer loop
-      vertex 5.09091 3.5 16.5
-      vertex 5.48091 4.728 17
-      vertex 5.48091 4.728 16.5
-    endloop
-  endfacet
-  facet normal -0.953089 0.302691 0
-    outer loop
-      vertex 5.48091 4.728 17
-      vertex 5.09091 3.5 16.5
-      vertex 5.09091 3.5 17
-    endloop
-  endfacet
-  facet normal -0.954216 0.299117 0
-    outer loop
-      vertex 5.68692 5.48399 16.5
-      vertex 6.14514 6.94577 17
-      vertex 6.14514 6.94577 16.5
-    endloop
-  endfacet
-  facet normal -0.954216 0.299117 0
-    outer loop
-      vertex 6.14514 6.94577 17
-      vertex 5.68692 5.48399 16.5
-      vertex 5.68692 5.48399 17
-    endloop
-  endfacet
-  facet normal -0.957421 0.288697 0
-    outer loop
-      vertex 6.14514 6.94577 16.5
-      vertex 6.22391 7.20699 17
-      vertex 6.22391 7.20699 16.5
-    endloop
-  endfacet
-  facet normal -0.957421 0.288697 0
-    outer loop
-      vertex 6.22391 7.20699 17
-      vertex 6.14514 6.94577 16.5
-      vertex 6.14514 6.94577 17
-    endloop
-  endfacet
-  facet normal -0.966501 0.256664 0
-    outer loop
-      vertex 6.22391 7.20699 16.5
-      vertex 6.31792 7.56099 17
-      vertex 6.31792 7.56099 16.5
-    endloop
-  endfacet
-  facet normal -0.966501 0.256664 0
-    outer loop
-      vertex 6.31792 7.56099 17
-      vertex 6.22391 7.20699 16.5
-      vertex 6.22391 7.20699 17
-    endloop
-  endfacet
-  facet normal 0.962757 0.270367 0
-    outer loop
-      vertex 6.38391 7.32599 17
-      vertex 6.31792 7.56099 16.5
-      vertex 6.31792 7.56099 17
-    endloop
-  endfacet
-  facet normal 0.962757 0.270367 0
-    outer loop
-      vertex 6.31792 7.56099 16.5
-      vertex 6.38391 7.32599 17
-      vertex 6.38391 7.32599 16.5
-    endloop
-  endfacet
-  facet normal 0.960577 0.278014 0
-    outer loop
-      vertex 6.51791 6.86299 17
-      vertex 6.38391 7.32599 16.5
-      vertex 6.38391 7.32599 17
-    endloop
-  endfacet
-  facet normal 0.960577 0.278014 0
-    outer loop
-      vertex 6.38391 7.32599 16.5
-      vertex 6.51791 6.86299 17
-      vertex 6.51791 6.86299 16.5
-    endloop
-  endfacet
-  facet normal 0.953677 0.300832 0
-    outer loop
-      vertex 6.95291 5.48399 17
-      vertex 6.51791 6.86299 16.5
-      vertex 6.51791 6.86299 17
-    endloop
-  endfacet
-  facet normal 0.953677 0.300832 0
-    outer loop
-      vertex 6.51791 6.86299 16.5
-      vertex 6.95291 5.48399 17
-      vertex 6.95291 5.48399 16.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 5.68692 5.48399 16.5
-      vertex 6.95291 5.48399 17
-      vertex 5.68692 5.48399 17
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 6.95291 5.48399 17
-      vertex 5.68692 5.48399 16.5
-      vertex 6.95291 5.48399 16.5
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 11.5018 5.29199 16.5
-      vertex 10.3128 5.29199 17
-      vertex 11.5018 5.29199 17
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 10.3128 5.29199 17
-      vertex 11.5018 5.29199 16.5
-      vertex 10.3128 5.29199 16.5
-    endloop
-  endfacet
-  facet normal 0.848209 0.529661 0
-    outer loop
-      vertex 12.6208 3.5 17
-      vertex 11.5018 5.29199 16.5
-      vertex 11.5018 5.29199 17
-    endloop
-  endfacet
-  facet normal 0.848209 0.529661 0
-    outer loop
-      vertex 11.5018 5.29199 16.5
-      vertex 12.6208 3.5 17
-      vertex 12.6208 3.5 16.5
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 13.7518 3.5 16.5
-      vertex 12.6208 3.5 17
-      vertex 13.7518 3.5 17
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 12.6208 3.5 17
-      vertex 13.7518 3.5 16.5
-      vertex 12.6208 3.5 16.5
-    endloop
-  endfacet
-  facet normal -0.836108 -0.548564 0
-    outer loop
-      vertex 13.7518 3.5 16.5
-      vertex 12.4488 5.48599 17
-      vertex 12.4488 5.48599 16.5
-    endloop
-  endfacet
-  facet normal -0.836108 -0.548564 0
-    outer loop
-      vertex 12.4488 5.48599 17
-      vertex 13.7518 3.5 16.5
-      vertex 13.7518 3.5 17
-    endloop
-  endfacet
-  facet normal -0.329974 0.94399 0
-    outer loop
-      vertex 12.7524 5.5921 16.5
-      vertex 12.4488 5.48599 17
-      vertex 12.7524 5.5921 17
-    endloop
-  endfacet
-  facet normal -0.329974 0.94399 0
-    outer loop
-      vertex 12.4488 5.48599 17
-      vertex 12.7524 5.5921 16.5
-      vertex 12.4488 5.48599 16.5
-    endloop
-  endfacet
-  facet normal -0.531579 0.847009 0
-    outer loop
-      vertex 13.0111 5.75444 16.5
-      vertex 12.7524 5.5921 17
-      vertex 13.0111 5.75444 17
-    endloop
-  endfacet
-  facet normal -0.531579 0.847009 0
-    outer loop
-      vertex 12.7524 5.5921 17
-      vertex 13.0111 5.75444 16.5
-      vertex 12.7524 5.5921 16.5
-    endloop
-  endfacet
-  facet normal -0.714875 0.699253 0
-    outer loop
-      vertex 13.0111 5.75444 16.5
-      vertex 13.2248 5.97299 17
-      vertex 13.2248 5.97299 16.5
-    endloop
-  endfacet
-  facet normal -0.714875 0.699253 0
-    outer loop
-      vertex 13.2248 5.97299 17
-      vertex 13.0111 5.75444 16.5
-      vertex 13.0111 5.75444 17
-    endloop
-  endfacet
-  facet normal -0.854024 0.520233 0
-    outer loop
-      vertex 13.2248 5.97299 16.5
-      vertex 13.3848 6.23566 17
-      vertex 13.3848 6.23566 16.5
-    endloop
-  endfacet
-  facet normal -0.854024 0.520233 0
-    outer loop
-      vertex 13.3848 6.23566 17
-      vertex 13.2248 5.97299 16.5
-      vertex 13.2248 5.97299 17
-    endloop
-  endfacet
-  facet normal -0.950404 0.311017 0
-    outer loop
-      vertex 13.3848 6.23566 16.5
-      vertex 13.4808 6.52899 17
-      vertex 13.4808 6.52899 16.5
-    endloop
-  endfacet
-  facet normal -0.950404 0.311017 0
-    outer loop
-      vertex 13.4808 6.52899 17
-      vertex 13.3848 6.23566 16.5
-      vertex 13.3848 6.23566 17
-    endloop
-  endfacet
-  facet normal -0.995159 0.0982786 0
-    outer loop
-      vertex 13.4808 6.52899 16.5
-      vertex 13.5128 6.853 17
-      vertex 13.5128 6.853 16.5
-    endloop
-  endfacet
-  facet normal -0.995159 0.0982786 0
-    outer loop
-      vertex 13.5128 6.853 17
-      vertex 13.4808 6.52899 16.5
-      vertex 13.4808 6.52899 17
-    endloop
-  endfacet
-  facet normal -0.992748 -0.120213 0
-    outer loop
-      vertex 13.5128 6.853 16.5
-      vertex 13.4607 7.28333 17
-      vertex 13.4607 7.28333 16.5
-    endloop
-  endfacet
-  facet normal -0.992748 -0.120213 0
-    outer loop
-      vertex 13.4607 7.28333 17
-      vertex 13.5128 6.853 16.5
-      vertex 13.5128 6.853 17
-    endloop
-  endfacet
-  facet normal -0.916301 -0.400491 0
-    outer loop
-      vertex 13.4607 7.28333 16.5
-      vertex 13.3044 7.64099 17
-      vertex 13.3044 7.64099 16.5
-    endloop
-  endfacet
-  facet normal -0.916301 -0.400491 0
-    outer loop
-      vertex 13.3044 7.64099 17
-      vertex 13.4607 7.28333 16.5
-      vertex 13.4607 7.28333 17
-    endloop
-  endfacet
-  facet normal -0.738049 -0.674747 0
-    outer loop
-      vertex 13.3044 7.64099 16.5
-      vertex 13.0438 7.92599 17
-      vertex 13.0438 7.92599 16.5
-    endloop
-  endfacet
-  facet normal -0.738049 -0.674747 0
-    outer loop
-      vertex 13.0438 7.92599 17
-      vertex 13.3044 7.64099 16.5
-      vertex 13.3044 7.64099 17
-    endloop
-  endfacet
-  facet normal -0.504426 -0.863455 0
-    outer loop
-      vertex 12.6882 8.13377 16.5
-      vertex 13.0438 7.92599 17
-      vertex 12.6882 8.13377 17
-    endloop
-  endfacet
-  facet normal -0.504426 -0.863455 -0
-    outer loop
-      vertex 13.0438 7.92599 17
-      vertex 12.6882 8.13377 16.5
-      vertex 13.0438 7.92599 16.5
-    endloop
-  endfacet
-  facet normal -0.270883 -0.962612 0
-    outer loop
-      vertex 12.2452 8.25844 16.5
-      vertex 12.6882 8.13377 17
-      vertex 12.2452 8.25844 17
-    endloop
-  endfacet
-  facet normal -0.270883 -0.962612 -0
-    outer loop
-      vertex 12.6882 8.13377 17
-      vertex 12.2452 8.25844 16.5
-      vertex 12.6882 8.13377 16.5
-    endloop
-  endfacet
-  facet normal -0.0781091 -0.996945 0
-    outer loop
-      vertex 11.7148 8.29999 16.5
-      vertex 12.2452 8.25844 17
-      vertex 11.7148 8.29999 17
-    endloop
-  endfacet
-  facet normal -0.0781091 -0.996945 -0
-    outer loop
-      vertex 12.2452 8.25844 17
-      vertex 11.7148 8.29999 16.5
-      vertex 12.2452 8.25844 16.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 9.30783 8.29999 16.5
-      vertex 11.7148 8.29999 17
-      vertex 9.30783 8.29999 17
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 11.7148 8.29999 17
-      vertex 9.30783 8.29999 16.5
-      vertex 11.7148 8.29999 16.5
+      vertex -10.3128 3.5 -16.5
+      vertex -9.30783 3.5 -17
+      vertex -10.3128 3.5 -17
     endloop
   endfacet
   facet normal 1 -0 0
     outer loop
-      vertex 9.30783 3.5 17
-      vertex 9.30783 8.29999 16.5
-      vertex 9.30783 8.29999 17
+      vertex -10.3128 3.5 -16.5
+      vertex -10.3128 5.29199 -17
+      vertex -10.3128 5.29199 -16.5
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
-      vertex 9.30783 8.29999 16.5
-      vertex 9.30783 3.5 17
-      vertex 9.30783 3.5 16.5
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 10.3128 3.5 16.5
-      vertex 9.30783 3.5 17
-      vertex 10.3128 3.5 17
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 9.30783 3.5 17
-      vertex 10.3128 3.5 16.5
-      vertex 9.30783 3.5 16.5
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex 10.3128 3.5 16.5
-      vertex 10.3128 5.29199 17
-      vertex 10.3128 5.29199 16.5
-    endloop
-  endfacet
-  facet normal -1 -0 0
-    outer loop
-      vertex 10.3128 5.29199 17
-      vertex 10.3128 3.5 16.5
-      vertex 10.3128 3.5 17
-    endloop
-  endfacet
-  facet normal -1 0 0
-    outer loop
-      vertex 10.3128 6.07199 16.5
-      vertex 10.3128 7.51999 17
-      vertex 10.3128 7.51999 16.5
-    endloop
-  endfacet
-  facet normal -1 -0 0
-    outer loop
-      vertex 10.3128 7.51999 17
-      vertex 10.3128 6.07199 16.5
-      vertex 10.3128 6.07199 17
-    endloop
-  endfacet
-  facet normal 0 1 -0
-    outer loop
-      vertex 11.6098 7.51999 16.5
-      vertex 10.3128 7.51999 17
-      vertex 11.6098 7.51999 17
-    endloop
-  endfacet
-  facet normal 0 1 0
-    outer loop
-      vertex 10.3128 7.51999 17
-      vertex 11.6098 7.51999 16.5
-      vertex 10.3128 7.51999 16.5
-    endloop
-  endfacet
-  facet normal 0.156558 0.987669 -0
-    outer loop
-      vertex 12.1054 7.44144 16.5
-      vertex 11.6098 7.51999 17
-      vertex 12.1054 7.44144 17
-    endloop
-  endfacet
-  facet normal 0.156558 0.987669 0
-    outer loop
-      vertex 11.6098 7.51999 17
-      vertex 12.1054 7.44144 16.5
-      vertex 11.6098 7.51999 16.5
-    endloop
-  endfacet
-  facet normal 0.621162 0.783682 -0
-    outer loop
-      vertex 12.4027 7.20576 16.5
-      vertex 12.1054 7.44144 17
-      vertex 12.4027 7.20576 17
-    endloop
-  endfacet
-  facet normal 0.621162 0.783682 0
-    outer loop
-      vertex 12.1054 7.44144 17
-      vertex 12.4027 7.20576 16.5
-      vertex 12.1054 7.44144 16.5
-    endloop
-  endfacet
-  facet normal 0.969611 0.244653 0
-    outer loop
-      vertex 12.5018 6.81299 17
-      vertex 12.4027 7.20576 16.5
-      vertex 12.4027 7.20576 17
-    endloop
-  endfacet
-  facet normal 0.969611 0.244653 0
-    outer loop
-      vertex 12.4027 7.20576 16.5
-      vertex 12.5018 6.81299 17
-      vertex 12.5018 6.81299 16.5
-    endloop
-  endfacet
-  facet normal 0.993695 -0.112114 0
-    outer loop
-      vertex 12.4774 6.59633 17
-      vertex 12.5018 6.81299 16.5
-      vertex 12.5018 6.81299 17
-    endloop
-  endfacet
-  facet normal 0.993695 -0.112114 0
-    outer loop
-      vertex 12.5018 6.81299 16.5
-      vertex 12.4774 6.59633 17
-      vertex 12.4774 6.59633 16.5
-    endloop
-  endfacet
-  facet normal 0.927541 -0.373722 0
-    outer loop
-      vertex 12.4041 6.41432 17
-      vertex 12.4774 6.59633 16.5
-      vertex 12.4774 6.59633 17
-    endloop
-  endfacet
-  facet normal 0.927541 -0.373722 0
-    outer loop
-      vertex 12.4774 6.59633 16.5
-      vertex 12.4041 6.41432 17
-      vertex 12.4041 6.41432 16.5
-    endloop
-  endfacet
-  facet normal 0.769624 -0.638497 0
-    outer loop
-      vertex 12.2818 6.267 17
-      vertex 12.4041 6.41432 16.5
-      vertex 12.4041 6.41432 17
-    endloop
-  endfacet
-  facet normal 0.769624 -0.638497 0
-    outer loop
-      vertex 12.4041 6.41432 16.5
-      vertex 12.2818 6.267 17
-      vertex 12.2818 6.267 16.5
-    endloop
-  endfacet
-  facet normal 0.539701 -0.841857 0
-    outer loop
-      vertex 12.1128 6.15866 16.5
-      vertex 12.2818 6.267 17
-      vertex 12.1128 6.15866 17
-    endloop
-  endfacet
-  facet normal 0.539701 -0.841857 0
-    outer loop
-      vertex 12.2818 6.267 17
-      vertex 12.1128 6.15866 16.5
-      vertex 12.2818 6.267 16.5
-    endloop
-  endfacet
-  facet normal 0.289404 -0.957207 0
-    outer loop
-      vertex 11.8978 6.09366 16.5
-      vertex 12.1128 6.15866 17
-      vertex 11.8978 6.09366 17
-    endloop
-  endfacet
-  facet normal 0.289404 -0.957207 0
-    outer loop
-      vertex 12.1128 6.15866 17
-      vertex 11.8978 6.09366 16.5
-      vertex 12.1128 6.15866 16.5
-    endloop
-  endfacet
-  facet normal 0.0827321 -0.996572 0
-    outer loop
-      vertex 11.6368 6.07199 16.5
-      vertex 11.8978 6.09366 17
-      vertex 11.6368 6.07199 17
-    endloop
-  endfacet
-  facet normal 0.0827321 -0.996572 0
-    outer loop
-      vertex 11.8978 6.09366 17
-      vertex 11.6368 6.07199 16.5
-      vertex 11.8978 6.09366 16.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 10.3128 6.07199 16.5
-      vertex 11.6368 6.07199 17
-      vertex 10.3128 6.07199 17
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 11.6368 6.07199 17
-      vertex 10.3128 6.07199 16.5
-      vertex 11.6368 6.07199 16.5
-    endloop
-  endfacet
-  facet normal 0 -1 0
-    outer loop
-      vertex 14.2218 8.29999 16.5
-      vertex 15.2268 8.29999 17
-      vertex 14.2218 8.29999 17
-    endloop
-  endfacet
-  facet normal 0 -1 -0
-    outer loop
-      vertex 15.2268 8.29999 17
-      vertex 14.2218 8.29999 16.5
-      vertex 15.2268 8.29999 16.5
+      vertex -10.3128 5.29199 -17
+      vertex -10.3128 3.5 -16.5
+      vertex -10.3128 3.5 -17
     endloop
   endfacet
   facet normal 1 -0 0
     outer loop
-      vertex 14.2218 3.5 17
-      vertex 14.2218 8.29999 16.5
-      vertex 14.2218 8.29999 17
+      vertex -10.3128 6.07199 -16.5
+      vertex -10.3128 7.51999 -17
+      vertex -10.3128 7.51999 -16.5
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
-      vertex 14.2218 8.29999 16.5
-      vertex 14.2218 3.5 17
-      vertex 14.2218 3.5 16.5
+      vertex -10.3128 7.51999 -17
+      vertex -10.3128 6.07199 -16.5
+      vertex -10.3128 6.07199 -17
     endloop
   endfacet
   facet normal 0 1 -0
     outer loop
-      vertex 15.2268 3.5 16.5
-      vertex 14.2218 3.5 17
-      vertex 15.2268 3.5 17
+      vertex -10.3128 7.51999 -17
+      vertex -11.6098 7.51999 -16.5
+      vertex -10.3128 7.51999 -16.5
     endloop
   endfacet
   facet normal 0 1 0
     outer loop
-      vertex 14.2218 3.5 17
-      vertex 15.2268 3.5 16.5
-      vertex 14.2218 3.5 16.5
+      vertex -11.6098 7.51999 -16.5
+      vertex -10.3128 7.51999 -17
+      vertex -11.6098 7.51999 -17
     endloop
   endfacet
-  facet normal -1 0 0
+  facet normal -0.156558 0.987669 0
     outer loop
-      vertex 15.2268 3.5 16.5
-      vertex 15.2268 8.29999 17
-      vertex 15.2268 8.29999 16.5
+      vertex -11.6098 7.51999 -17
+      vertex -12.1054 7.44144 -16.5
+      vertex -11.6098 7.51999 -16.5
     endloop
   endfacet
-  facet normal -1 -0 0
+  facet normal -0.156558 0.987669 0
     outer loop
-      vertex 15.2268 8.29999 17
-      vertex 15.2268 3.5 16.5
-      vertex 15.2268 3.5 17
+      vertex -12.1054 7.44144 -16.5
+      vertex -11.6098 7.51999 -17
+      vertex -12.1054 7.44144 -17
     endloop
   endfacet
-  facet normal -0.254662 0.96703 0
+  facet normal -0.621162 0.783682 0
     outer loop
-      vertex 19.5268 3.65999 16.5
-      vertex 19.0711 3.53999 17
-      vertex 19.5268 3.65999 17
+      vertex -12.1054 7.44144 -17
+      vertex -12.4027 7.20576 -16.5
+      vertex -12.1054 7.44144 -16.5
     endloop
   endfacet
-  facet normal -0.254662 0.96703 0
+  facet normal -0.621162 0.783682 0
     outer loop
-      vertex 19.0711 3.53999 17
-      vertex 19.5268 3.65999 16.5
-      vertex 19.0711 3.53999 16.5
+      vertex -12.4027 7.20576 -16.5
+      vertex -12.1054 7.44144 -17
+      vertex -12.4027 7.20576 -17
     endloop
   endfacet
-  facet normal -0.474955 0.88001 0
+  facet normal -0.969611 0.244653 0
     outer loop
-      vertex 19.8973 3.85999 16.5
-      vertex 19.5268 3.65999 17
-      vertex 19.8973 3.85999 17
+      vertex -12.5018 6.81299 -17
+      vertex -12.4027 7.20576 -16.5
+      vertex -12.4027 7.20576 -17
     endloop
   endfacet
-  facet normal -0.474955 0.88001 0
+  facet normal -0.969611 0.244653 0
     outer loop
-      vertex 19.5268 3.65999 17
-      vertex 19.8973 3.85999 16.5
-      vertex 19.5268 3.65999 16.5
+      vertex -12.4027 7.20576 -16.5
+      vertex -12.5018 6.81299 -17
+      vertex -12.5018 6.81299 -16.5
     endloop
   endfacet
-  facet normal -0.705981 0.70823 0
+  facet normal -0.993695 -0.112114 0
     outer loop
-      vertex 20.1712 4.133 16.5
-      vertex 19.8973 3.85999 17
-      vertex 20.1712 4.133 17
+      vertex -12.4774 6.59633 -17
+      vertex -12.5018 6.81299 -16.5
+      vertex -12.5018 6.81299 -17
     endloop
   endfacet
-  facet normal -0.705981 0.70823 0
+  facet normal -0.993695 -0.112114 0
     outer loop
-      vertex 19.8973 3.85999 17
-      vertex 20.1712 4.133 16.5
-      vertex 19.8973 3.85999 16.5
+      vertex -12.5018 6.81299 -16.5
+      vertex -12.4774 6.59633 -17
+      vertex -12.4774 6.59633 -16.5
     endloop
   endfacet
-  facet normal -0.899836 0.436228 0
+  facet normal -0.927541 -0.373722 0
     outer loop
-      vertex 20.1712 4.133 16.5
-      vertex 20.3356 4.47198 17
-      vertex 20.3356 4.47198 16.5
+      vertex -12.4041 6.41432 -17
+      vertex -12.4774 6.59633 -16.5
+      vertex -12.4774 6.59633 -17
     endloop
   endfacet
-  facet normal -0.899836 0.436228 0
+  facet normal -0.927541 -0.373722 0
     outer loop
-      vertex 20.3356 4.47198 17
-      vertex 20.1712 4.133 16.5
-      vertex 20.1712 4.133 17
+      vertex -12.4774 6.59633 -16.5
+      vertex -12.4041 6.41432 -17
+      vertex -12.4041 6.41432 -16.5
     endloop
   endfacet
-  facet normal -0.990977 0.134032 0
+  facet normal -0.769624 -0.638497 0
     outer loop
-      vertex 20.3356 4.47198 16.5
-      vertex 20.3903 4.877 17
-      vertex 20.3903 4.877 16.5
+      vertex -12.2818 6.267 -17
+      vertex -12.4041 6.41432 -16.5
+      vertex -12.4041 6.41432 -17
     endloop
   endfacet
-  facet normal -0.990977 0.134032 0
+  facet normal -0.769624 -0.638497 0
     outer loop
-      vertex 20.3903 4.877 17
-      vertex 20.3356 4.47198 16.5
-      vertex 20.3356 4.47198 17
+      vertex -12.4041 6.41432 -16.5
+      vertex -12.2818 6.267 -17
+      vertex -12.2818 6.267 -16.5
     endloop
   endfacet
-  facet normal -0.993913 -0.110172 0
+  facet normal -0.539701 -0.841857 0
     outer loop
-      vertex 20.3903 4.877 16.5
-      vertex 20.3562 5.18466 17
-      vertex 20.3562 5.18466 16.5
+      vertex -12.2818 6.267 -17
+      vertex -12.1128 6.15866 -16.5
+      vertex -12.2818 6.267 -16.5
     endloop
   endfacet
-  facet normal -0.993913 -0.110172 0
+  facet normal -0.539701 -0.841857 -0
     outer loop
-      vertex 20.3562 5.18466 17
-      vertex 20.3903 4.877 16.5
-      vertex 20.3903 4.877 17
+      vertex -12.1128 6.15866 -16.5
+      vertex -12.2818 6.267 -17
+      vertex -12.1128 6.15866 -17
     endloop
   endfacet
-  facet normal -0.932544 -0.361056 0
+  facet normal -0.289404 -0.957207 0
     outer loop
-      vertex 20.3562 5.18466 16.5
-      vertex 20.2539 5.44899 17
-      vertex 20.2539 5.44899 16.5
+      vertex -12.1128 6.15866 -17
+      vertex -11.8978 6.09366 -16.5
+      vertex -12.1128 6.15866 -16.5
     endloop
   endfacet
-  facet normal -0.932544 -0.361056 0
+  facet normal -0.289404 -0.957207 -0
     outer loop
-      vertex 20.2539 5.44899 17
-      vertex 20.3562 5.18466 16.5
-      vertex 20.3562 5.18466 17
+      vertex -11.8978 6.09366 -16.5
+      vertex -12.1128 6.15866 -17
+      vertex -11.8978 6.09366 -17
     endloop
   endfacet
-  facet normal -0.791686 -0.610928 0
+  facet normal -0.0827321 -0.996572 0
     outer loop
-      vertex 20.2539 5.44899 16.5
-      vertex 20.0833 5.67 17
-      vertex 20.0833 5.67 16.5
+      vertex -11.8978 6.09366 -17
+      vertex -11.6368 6.07199 -16.5
+      vertex -11.8978 6.09366 -16.5
     endloop
   endfacet
-  facet normal -0.791686 -0.610928 0
+  facet normal -0.0827321 -0.996572 -0
     outer loop
-      vertex 20.0833 5.67 17
-      vertex 20.2539 5.44899 16.5
-      vertex 20.2539 5.44899 17
-    endloop
-  endfacet
-  facet normal -0.595795 -0.803137 0
-    outer loop
-      vertex 19.8483 5.84433 16.5
-      vertex 20.0833 5.67 17
-      vertex 19.8483 5.84433 17
-    endloop
-  endfacet
-  facet normal -0.595795 -0.803137 -0
-    outer loop
-      vertex 20.0833 5.67 17
-      vertex 19.8483 5.84433 16.5
-      vertex 20.0833 5.67 16.5
-    endloop
-  endfacet
-  facet normal -0.382616 -0.923908 0
-    outer loop
-      vertex 19.5513 5.96733 16.5
-      vertex 19.8483 5.84433 17
-      vertex 19.5513 5.96733 17
-    endloop
-  endfacet
-  facet normal -0.382616 -0.923908 -0
-    outer loop
-      vertex 19.8483 5.84433 17
-      vertex 19.5513 5.96733 16.5
-      vertex 19.8483 5.84433 16.5
-    endloop
-  endfacet
-  facet normal -0.195739 -0.980656 0
-    outer loop
-      vertex 19.1923 6.03899 16.5
-      vertex 19.5513 5.96733 17
-      vertex 19.1923 6.03899 17
-    endloop
-  endfacet
-  facet normal -0.195739 -0.980656 -0
-    outer loop
-      vertex 19.5513 5.96733 17
-      vertex 19.1923 6.03899 16.5
-      vertex 19.5513 5.96733 16.5
-    endloop
-  endfacet
-  facet normal -0.288023 0.957624 0
-    outer loop
-      vertex 19.4764 6.12444 16.5
-      vertex 19.1923 6.03899 17
-      vertex 19.4764 6.12444 17
-    endloop
-  endfacet
-  facet normal -0.288023 0.957624 0
-    outer loop
-      vertex 19.1923 6.03899 17
-      vertex 19.4764 6.12444 16.5
-      vertex 19.1923 6.03899 16.5
-    endloop
-  endfacet
-  facet normal -0.477884 0.878423 0
-    outer loop
-      vertex 19.7074 6.25011 16.5
-      vertex 19.4764 6.12444 17
-      vertex 19.7074 6.25011 17
-    endloop
-  endfacet
-  facet normal -0.477884 0.878423 0
-    outer loop
-      vertex 19.4764 6.12444 17
-      vertex 19.7074 6.25011 16.5
-      vertex 19.4764 6.12444 16.5
-    endloop
-  endfacet
-  facet normal -0.68199 0.731362 0
-    outer loop
-      vertex 19.8853 6.41599 16.5
-      vertex 19.7074 6.25011 17
-      vertex 19.8853 6.41599 17
-    endloop
-  endfacet
-  facet normal -0.68199 0.731362 0
-    outer loop
-      vertex 19.7074 6.25011 17
-      vertex 19.8853 6.41599 16.5
-      vertex 19.7074 6.25011 16.5
-    endloop
-  endfacet
-  facet normal -0.845602 0.533814 0
-    outer loop
-      vertex 19.8853 6.41599 16.5
-      vertex 20.012 6.61665 17
-      vertex 20.012 6.61665 16.5
-    endloop
-  endfacet
-  facet normal -0.845602 0.533814 0
-    outer loop
-      vertex 20.012 6.61665 17
-      vertex 19.8853 6.41599 16.5
-      vertex 19.8853 6.41599 17
-    endloop
-  endfacet
-  facet normal -0.948974 0.315354 0
-    outer loop
-      vertex 20.012 6.61665 16.5
-      vertex 20.088 6.84532 17
-      vertex 20.088 6.84532 16.5
-    endloop
-  endfacet
-  facet normal -0.948974 0.315354 0
-    outer loop
-      vertex 20.088 6.84532 17
-      vertex 20.012 6.61665 16.5
-      vertex 20.012 6.61665 17
-    endloop
-  endfacet
-  facet normal -0.99516 0.0982677 0
-    outer loop
-      vertex 20.088 6.84532 16.5
-      vertex 20.1133 7.10199 17
-      vertex 20.1133 7.10199 16.5
-    endloop
-  endfacet
-  facet normal -0.99516 0.0982677 0
-    outer loop
-      vertex 20.1133 7.10199 17
-      vertex 20.088 6.84532 16.5
-      vertex 20.088 6.84532 17
-    endloop
-  endfacet
-  facet normal -0.990499 -0.137522 0
-    outer loop
-      vertex 20.1133 7.10199 16.5
-      vertex 20.063 7.46455 17
-      vertex 20.063 7.46455 16.5
-    endloop
-  endfacet
-  facet normal -0.990499 -0.137522 0
-    outer loop
-      vertex 20.063 7.46455 17
-      vertex 20.1133 7.10199 16.5
-      vertex 20.1133 7.10199 17
-    endloop
-  endfacet
-  facet normal -0.892217 -0.451607 0
-    outer loop
-      vertex 20.063 7.46455 16.5
-      vertex 19.912 7.76288 17
-      vertex 19.912 7.76288 16.5
-    endloop
-  endfacet
-  facet normal -0.892217 -0.451607 0
-    outer loop
-      vertex 19.912 7.76288 17
-      vertex 20.063 7.46455 16.5
-      vertex 20.063 7.46455 17
-    endloop
-  endfacet
-  facet normal -0.68112 -0.732172 0
-    outer loop
-      vertex 19.6603 7.99699 16.5
-      vertex 19.912 7.76288 17
-      vertex 19.6603 7.99699 17
-    endloop
-  endfacet
-  facet normal -0.68112 -0.732172 -0
-    outer loop
-      vertex 19.912 7.76288 17
-      vertex 19.6603 7.99699 16.5
-      vertex 19.912 7.76288 16.5
-    endloop
-  endfacet
-  facet normal -0.433764 -0.901027 0
-    outer loop
-      vertex 19.3107 8.16533 16.5
-      vertex 19.6603 7.99699 17
-      vertex 19.3107 8.16533 17
-    endloop
-  endfacet
-  facet normal -0.433764 -0.901027 -0
-    outer loop
-      vertex 19.6603 7.99699 17
-      vertex 19.3107 8.16533 16.5
-      vertex 19.6603 7.99699 16.5
-    endloop
-  endfacet
-  facet normal -0.221336 -0.975198 0
-    outer loop
-      vertex 18.8657 8.26633 16.5
-      vertex 19.3107 8.16533 17
-      vertex 18.8657 8.26633 17
-    endloop
-  endfacet
-  facet normal -0.221336 -0.975198 -0
-    outer loop
-      vertex 19.3107 8.16533 17
-      vertex 18.8657 8.26633 16.5
-      vertex 19.3107 8.16533 16.5
-    endloop
-  endfacet
-  facet normal -0.0621747 -0.998065 0
-    outer loop
-      vertex 18.3253 8.29999 16.5
-      vertex 18.8657 8.26633 17
-      vertex 18.3253 8.29999 17
-    endloop
-  endfacet
-  facet normal -0.0621747 -0.998065 -0
-    outer loop
-      vertex 18.8657 8.26633 17
-      vertex 18.3253 8.29999 16.5
-      vertex 18.8657 8.26633 16.5
+      vertex -11.6368 6.07199 -16.5
+      vertex -11.8978 6.09366 -17
+      vertex -11.6368 6.07199 -17
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
-      vertex 16.1203 8.29999 16.5
-      vertex 18.3253 8.29999 17
-      vertex 16.1203 8.29999 17
+      vertex -11.6368 6.07199 -17
+      vertex -10.3128 6.07199 -16.5
+      vertex -11.6368 6.07199 -16.5
     endloop
   endfacet
   facet normal 0 -1 -0
     outer loop
-      vertex 18.3253 8.29999 17
-      vertex 16.1203 8.29999 16.5
-      vertex 18.3253 8.29999 16.5
+      vertex -10.3128 6.07199 -16.5
+      vertex -11.6368 6.07199 -17
+      vertex -10.3128 6.07199 -17
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -15.2268 8.29999 -17
+      vertex -14.2218 8.29999 -16.5
+      vertex -15.2268 8.29999 -16.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -14.2218 8.29999 -16.5
+      vertex -15.2268 8.29999 -17
+      vertex -14.2218 8.29999 -17
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -14.2218 3.5 -17
+      vertex -14.2218 8.29999 -16.5
+      vertex -14.2218 8.29999 -17
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -14.2218 8.29999 -16.5
+      vertex -14.2218 3.5 -17
+      vertex -14.2218 3.5 -16.5
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -14.2218 3.5 -17
+      vertex -15.2268 3.5 -16.5
+      vertex -14.2218 3.5 -16.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -15.2268 3.5 -16.5
+      vertex -14.2218 3.5 -17
+      vertex -15.2268 3.5 -17
     endloop
   endfacet
   facet normal 1 -0 0
     outer loop
-      vertex 16.1203 3.5 17
-      vertex 16.1203 8.29999 16.5
-      vertex 16.1203 8.29999 17
+      vertex -15.2268 3.5 -16.5
+      vertex -15.2268 8.29999 -17
+      vertex -15.2268 8.29999 -16.5
     endloop
   endfacet
   facet normal 1 0 0
     outer loop
-      vertex 16.1203 8.29999 16.5
-      vertex 16.1203 3.5 17
-      vertex 16.1203 3.5 16.5
+      vertex -15.2268 8.29999 -17
+      vertex -15.2268 3.5 -16.5
+      vertex -15.2268 3.5 -17
     endloop
   endfacet
-  facet normal 0 1 -0
+  facet normal 0.254662 0.96703 -0
     outer loop
-      vertex 18.5303 3.5 16.5
-      vertex 16.1203 3.5 17
-      vertex 18.5303 3.5 17
+      vertex -19.0711 3.53999 -17
+      vertex -19.5268 3.65999 -16.5
+      vertex -19.0711 3.53999 -16.5
     endloop
   endfacet
-  facet normal 0 1 0
+  facet normal 0.254662 0.96703 0
     outer loop
-      vertex 16.1203 3.5 17
-      vertex 18.5303 3.5 16.5
-      vertex 16.1203 3.5 16.5
+      vertex -19.5268 3.65999 -16.5
+      vertex -19.0711 3.53999 -17
+      vertex -19.5268 3.65999 -17
     endloop
   endfacet
-  facet normal -0.0737525 0.997277 0
+  facet normal 0.474955 0.88001 -0
     outer loop
-      vertex 19.0711 3.53999 16.5
-      vertex 18.5303 3.5 17
-      vertex 19.0711 3.53999 17
+      vertex -19.5268 3.65999 -17
+      vertex -19.8973 3.85999 -16.5
+      vertex -19.5268 3.65999 -16.5
     endloop
   endfacet
-  facet normal -0.0737525 0.997277 0
+  facet normal 0.474955 0.88001 0
     outer loop
-      vertex 18.5303 3.5 17
-      vertex 19.0711 3.53999 16.5
-      vertex 18.5303 3.5 16.5
+      vertex -19.8973 3.85999 -16.5
+      vertex -19.5268 3.65999 -17
+      vertex -19.8973 3.85999 -17
     endloop
   endfacet
-  facet normal -1 0 0
+  facet normal 0.705981 0.70823 -0
     outer loop
-      vertex 17.1253 6.37999 16.5
-      vertex 17.1253 7.55399 17
-      vertex 17.1253 7.55399 16.5
+      vertex -19.8973 3.85999 -17
+      vertex -20.1712 4.133 -16.5
+      vertex -19.8973 3.85999 -16.5
     endloop
   endfacet
-  facet normal -1 -0 0
+  facet normal 0.705981 0.70823 0
     outer loop
-      vertex 17.1253 7.55399 17
-      vertex 17.1253 6.37999 16.5
-      vertex 17.1253 6.37999 17
+      vertex -20.1712 4.133 -16.5
+      vertex -19.8973 3.85999 -17
+      vertex -20.1712 4.133 -17
     endloop
   endfacet
-  facet normal 0 1 -0
+  facet normal 0.899836 0.436228 0
     outer loop
-      vertex 18.2783 7.55399 16.5
-      vertex 17.1253 7.55399 17
-      vertex 18.2783 7.55399 17
+      vertex -20.1712 4.133 -16.5
+      vertex -20.3356 4.47198 -17
+      vertex -20.3356 4.47198 -16.5
     endloop
   endfacet
-  facet normal 0 1 0
+  facet normal 0.899836 0.436228 0
     outer loop
-      vertex 17.1253 7.55399 17
-      vertex 18.2783 7.55399 16.5
-      vertex 17.1253 7.55399 16.5
+      vertex -20.3356 4.47198 -17
+      vertex -20.1712 4.133 -16.5
+      vertex -20.1712 4.133 -17
     endloop
   endfacet
-  facet normal 0.0598353 0.998208 -0
+  facet normal 0.990977 0.134032 0
     outer loop
-      vertex 18.5286 7.53899 16.5
-      vertex 18.2783 7.55399 17
-      vertex 18.5286 7.53899 17
+      vertex -20.3356 4.47198 -16.5
+      vertex -20.3903 4.877 -17
+      vertex -20.3903 4.877 -16.5
     endloop
   endfacet
-  facet normal 0.0598353 0.998208 0
+  facet normal 0.990977 0.134032 0
     outer loop
-      vertex 18.2783 7.55399 17
-      vertex 18.5286 7.53899 16.5
-      vertex 18.2783 7.55399 16.5
+      vertex -20.3903 4.877 -17
+      vertex -20.3356 4.47198 -16.5
+      vertex -20.3356 4.47198 -17
     endloop
   endfacet
-  facet normal 0.214078 0.976817 -0
+  facet normal 0.993913 -0.110172 0
     outer loop
-      vertex 18.7339 7.49399 16.5
-      vertex 18.5286 7.53899 17
-      vertex 18.7339 7.49399 17
+      vertex -20.3903 4.877 -16.5
+      vertex -20.3562 5.18466 -17
+      vertex -20.3562 5.18466 -16.5
     endloop
   endfacet
-  facet normal 0.214078 0.976817 0
+  facet normal 0.993913 -0.110172 0
     outer loop
-      vertex 18.5286 7.53899 17
-      vertex 18.7339 7.49399 16.5
-      vertex 18.5286 7.53899 16.5
+      vertex -20.3562 5.18466 -17
+      vertex -20.3903 4.877 -16.5
+      vertex -20.3903 4.877 -17
     endloop
   endfacet
-  facet normal 0.423451 0.905919 -0
+  facet normal 0.932544 -0.361056 0
     outer loop
-      vertex 18.8943 7.41899 16.5
-      vertex 18.7339 7.49399 17
-      vertex 18.8943 7.41899 17
+      vertex -20.3562 5.18466 -16.5
+      vertex -20.2539 5.44899 -17
+      vertex -20.2539 5.44899 -16.5
     endloop
   endfacet
-  facet normal 0.423451 0.905919 0
+  facet normal 0.932544 -0.361056 0
     outer loop
-      vertex 18.7339 7.49399 17
-      vertex 18.8943 7.41899 16.5
-      vertex 18.7339 7.49399 16.5
+      vertex -20.2539 5.44899 -17
+      vertex -20.3562 5.18466 -16.5
+      vertex -20.3562 5.18466 -17
     endloop
   endfacet
-  facet normal 0.689486 0.724299 -0
+  facet normal 0.791686 -0.610928 0
     outer loop
-      vertex 19.0099 7.30899 16.5
-      vertex 18.8943 7.41899 17
-      vertex 19.0099 7.30899 17
+      vertex -20.2539 5.44899 -16.5
+      vertex -20.0833 5.67 -17
+      vertex -20.0833 5.67 -16.5
     endloop
   endfacet
-  facet normal 0.689486 0.724299 0
+  facet normal 0.791686 -0.610928 0
     outer loop
-      vertex 18.8943 7.41899 17
-      vertex 19.0099 7.30899 16.5
-      vertex 18.8943 7.41899 16.5
+      vertex -20.0833 5.67 -17
+      vertex -20.2539 5.44899 -16.5
+      vertex -20.2539 5.44899 -17
     endloop
   endfacet
-  facet normal 0.909126 0.416522 0
+  facet normal 0.595795 -0.803137 0
     outer loop
-      vertex 19.0792 7.15765 17
-      vertex 19.0099 7.30899 16.5
-      vertex 19.0099 7.30899 17
+      vertex -20.0833 5.67 -17
+      vertex -19.8483 5.84433 -16.5
+      vertex -20.0833 5.67 -16.5
     endloop
   endfacet
-  facet normal 0.909126 0.416522 0
+  facet normal 0.595795 -0.803137 0
     outer loop
-      vertex 19.0099 7.30899 16.5
-      vertex 19.0792 7.15765 17
-      vertex 19.0792 7.15765 16.5
+      vertex -19.8483 5.84433 -16.5
+      vertex -20.0833 5.67 -17
+      vertex -19.8483 5.84433 -17
     endloop
   endfacet
-  facet normal 0.992878 0.119136 0
+  facet normal 0.382616 -0.923908 0
     outer loop
-      vertex 19.1023 6.965 17
-      vertex 19.0792 7.15765 16.5
-      vertex 19.0792 7.15765 17
+      vertex -19.8483 5.84433 -17
+      vertex -19.5513 5.96733 -16.5
+      vertex -19.8483 5.84433 -16.5
     endloop
   endfacet
-  facet normal 0.992878 0.119136 0
+  facet normal 0.382616 -0.923908 0
     outer loop
-      vertex 19.0792 7.15765 16.5
-      vertex 19.1023 6.965 17
-      vertex 19.1023 6.965 16.5
+      vertex -19.5513 5.96733 -16.5
+      vertex -19.8483 5.84433 -17
+      vertex -19.5513 5.96733 -17
     endloop
   endfacet
-  facet normal 0.992789 -0.119878 0
+  facet normal 0.195739 -0.980656 0
     outer loop
-      vertex 19.0808 6.78644 17
-      vertex 19.1023 6.965 16.5
-      vertex 19.1023 6.965 17
+      vertex -19.5513 5.96733 -17
+      vertex -19.1923 6.03899 -16.5
+      vertex -19.5513 5.96733 -16.5
     endloop
   endfacet
-  facet normal 0.992789 -0.119878 0
+  facet normal 0.195739 -0.980656 0
     outer loop
-      vertex 19.1023 6.965 16.5
-      vertex 19.0808 6.78644 17
-      vertex 19.0808 6.78644 16.5
+      vertex -19.1923 6.03899 -16.5
+      vertex -19.5513 5.96733 -17
+      vertex -19.1923 6.03899 -17
     endloop
   endfacet
-  facet normal 0.914667 -0.404208 0
+  facet normal 0.288023 0.957624 -0
     outer loop
-      vertex 19.0161 6.64011 17
-      vertex 19.0808 6.78644 16.5
-      vertex 19.0808 6.78644 17
+      vertex -19.1923 6.03899 -17
+      vertex -19.4764 6.12444 -16.5
+      vertex -19.1923 6.03899 -16.5
     endloop
   endfacet
-  facet normal 0.914667 -0.404208 0
+  facet normal 0.288023 0.957624 0
     outer loop
-      vertex 19.0808 6.78644 16.5
-      vertex 19.0161 6.64011 17
-      vertex 19.0161 6.64011 16.5
+      vertex -19.4764 6.12444 -16.5
+      vertex -19.1923 6.03899 -17
+      vertex -19.4764 6.12444 -17
     endloop
   endfacet
-  facet normal 0.727037 -0.686598 0
+  facet normal 0.477884 0.878423 -0
     outer loop
-      vertex 18.9083 6.52599 17
-      vertex 19.0161 6.64011 16.5
-      vertex 19.0161 6.64011 17
+      vertex -19.4764 6.12444 -17
+      vertex -19.7074 6.25011 -16.5
+      vertex -19.4764 6.12444 -16.5
     endloop
   endfacet
-  facet normal 0.727037 -0.686598 0
+  facet normal 0.477884 0.878423 0
     outer loop
-      vertex 19.0161 6.64011 16.5
-      vertex 18.9083 6.52599 17
-      vertex 18.9083 6.52599 16.5
+      vertex -19.7074 6.25011 -16.5
+      vertex -19.4764 6.12444 -17
+      vertex -19.7074 6.25011 -17
     endloop
   endfacet
-  facet normal 0.462569 -0.886583 0
+  facet normal 0.68199 0.731362 -0
     outer loop
-      vertex 18.7529 6.44489 16.5
-      vertex 18.9083 6.52599 17
-      vertex 18.7529 6.44489 17
+      vertex -19.7074 6.25011 -17
+      vertex -19.8853 6.41599 -16.5
+      vertex -19.7074 6.25011 -16.5
     endloop
   endfacet
-  facet normal 0.462569 -0.886583 0
+  facet normal 0.68199 0.731362 0
     outer loop
-      vertex 18.9083 6.52599 17
-      vertex 18.7529 6.44489 16.5
-      vertex 18.9083 6.52599 16.5
+      vertex -19.8853 6.41599 -16.5
+      vertex -19.7074 6.25011 -17
+      vertex -19.8853 6.41599 -17
     endloop
   endfacet
-  facet normal 0.228202 -0.973614 0
+  facet normal 0.845602 0.533814 0
     outer loop
-      vertex 18.5452 6.39621 16.5
-      vertex 18.7529 6.44489 17
-      vertex 18.5452 6.39621 17
+      vertex -19.8853 6.41599 -16.5
+      vertex -20.012 6.61665 -17
+      vertex -20.012 6.61665 -16.5
     endloop
   endfacet
-  facet normal 0.228202 -0.973614 0
+  facet normal 0.845602 0.533814 0
     outer loop
-      vertex 18.7529 6.44489 17
-      vertex 18.5452 6.39621 16.5
-      vertex 18.7529 6.44489 16.5
+      vertex -20.012 6.61665 -17
+      vertex -19.8853 6.41599 -16.5
+      vertex -19.8853 6.41599 -17
     endloop
   endfacet
-  facet normal 0.0622907 -0.998058 0
+  facet normal 0.948974 0.315354 0
     outer loop
-      vertex 18.2853 6.37999 16.5
-      vertex 18.5452 6.39621 17
-      vertex 18.2853 6.37999 17
+      vertex -20.012 6.61665 -16.5
+      vertex -20.088 6.84532 -17
+      vertex -20.088 6.84532 -16.5
     endloop
   endfacet
-  facet normal 0.0622907 -0.998058 0
+  facet normal 0.948974 0.315354 0
     outer loop
-      vertex 18.5452 6.39621 17
-      vertex 18.2853 6.37999 16.5
-      vertex 18.5452 6.39621 16.5
+      vertex -20.088 6.84532 -17
+      vertex -20.012 6.61665 -16.5
+      vertex -20.012 6.61665 -17
     endloop
   endfacet
-  facet normal 0 -1 0
+  facet normal 0.99516 0.0982677 0
     outer loop
-      vertex 17.1253 6.37999 16.5
-      vertex 18.2853 6.37999 17
-      vertex 17.1253 6.37999 17
+      vertex -20.088 6.84532 -16.5
+      vertex -20.1133 7.10199 -17
+      vertex -20.1133 7.10199 -16.5
     endloop
   endfacet
-  facet normal 0 -1 -0
+  facet normal 0.99516 0.0982677 0
     outer loop
-      vertex 18.2853 6.37999 17
-      vertex 17.1253 6.37999 16.5
-      vertex 18.2853 6.37999 16.5
+      vertex -20.1133 7.10199 -17
+      vertex -20.088 6.84532 -16.5
+      vertex -20.088 6.84532 -17
     endloop
   endfacet
-  facet normal -1 0 0
+  facet normal 0.990499 -0.137522 0
     outer loop
-      vertex 17.1253 4.24599 16.5
-      vertex 17.1253 5.63699 17
-      vertex 17.1253 5.63699 16.5
+      vertex -20.1133 7.10199 -16.5
+      vertex -20.063 7.46455 -17
+      vertex -20.063 7.46455 -16.5
     endloop
   endfacet
-  facet normal -1 -0 0
+  facet normal 0.990499 -0.137522 0
     outer loop
-      vertex 17.1253 5.63699 17
-      vertex 17.1253 4.24599 16.5
-      vertex 17.1253 4.24599 17
+      vertex -20.063 7.46455 -17
+      vertex -20.1133 7.10199 -16.5
+      vertex -20.1133 7.10199 -17
     endloop
   endfacet
-  facet normal 0 1 -0
+  facet normal 0.892217 -0.451607 0
     outer loop
-      vertex 18.4083 5.63699 16.5
-      vertex 17.1253 5.63699 17
-      vertex 18.4083 5.63699 17
+      vertex -20.063 7.46455 -16.5
+      vertex -19.912 7.76288 -17
+      vertex -19.912 7.76288 -16.5
     endloop
   endfacet
-  facet normal 0 1 0
+  facet normal 0.892217 -0.451607 0
     outer loop
-      vertex 17.1253 5.63699 17
-      vertex 18.4083 5.63699 16.5
-      vertex 17.1253 5.63699 16.5
+      vertex -19.912 7.76288 -17
+      vertex -20.063 7.46455 -16.5
+      vertex -20.063 7.46455 -17
     endloop
   endfacet
-  facet normal 0.138684 0.990337 -0
+  facet normal 0.68112 -0.732172 0
     outer loop
-      vertex 18.9494 5.56122 16.5
-      vertex 18.4083 5.63699 17
-      vertex 18.9494 5.56122 17
+      vertex -19.912 7.76288 -17
+      vertex -19.6603 7.99699 -16.5
+      vertex -19.912 7.76288 -16.5
     endloop
   endfacet
-  facet normal 0.138684 0.990337 0
+  facet normal 0.68112 -0.732172 0
     outer loop
-      vertex 18.4083 5.63699 17
-      vertex 18.9494 5.56122 16.5
-      vertex 18.4083 5.63699 16.5
+      vertex -19.6603 7.99699 -16.5
+      vertex -19.912 7.76288 -17
+      vertex -19.6603 7.99699 -17
     endloop
   endfacet
-  facet normal 0.573594 0.81914 -0
+  facet normal 0.433764 -0.901027 0
     outer loop
-      vertex 19.2741 5.33388 16.5
-      vertex 18.9494 5.56122 17
-      vertex 19.2741 5.33388 17
+      vertex -19.6603 7.99699 -17
+      vertex -19.3107 8.16533 -16.5
+      vertex -19.6603 7.99699 -16.5
     endloop
   endfacet
-  facet normal 0.573594 0.81914 0
+  facet normal 0.433764 -0.901027 0
     outer loop
-      vertex 18.9494 5.56122 17
-      vertex 19.2741 5.33388 16.5
-      vertex 18.9494 5.56122 16.5
+      vertex -19.3107 8.16533 -16.5
+      vertex -19.6603 7.99699 -17
+      vertex -19.3107 8.16533 -17
     endloop
   endfacet
-  facet normal 0.96154 0.274665 0
+  facet normal 0.221336 -0.975198 0
     outer loop
-      vertex 19.3823 4.95499 17
-      vertex 19.2741 5.33388 16.5
-      vertex 19.2741 5.33388 17
+      vertex -19.3107 8.16533 -17
+      vertex -18.8657 8.26633 -16.5
+      vertex -19.3107 8.16533 -16.5
     endloop
   endfacet
-  facet normal 0.96154 0.274665 0
+  facet normal 0.221336 -0.975198 0
     outer loop
-      vertex 19.2741 5.33388 16.5
-      vertex 19.3823 4.95499 17
-      vertex 19.3823 4.95499 16.5
+      vertex -18.8657 8.26633 -16.5
+      vertex -19.3107 8.16533 -17
+      vertex -18.8657 8.26633 -17
     endloop
   endfacet
-  facet normal 0.993391 -0.114781 0
+  facet normal 0.0621747 -0.998065 0
     outer loop
-      vertex 19.3573 4.73854 17
-      vertex 19.3823 4.95499 16.5
-      vertex 19.3823 4.95499 17
+      vertex -18.8657 8.26633 -17
+      vertex -18.3253 8.29999 -16.5
+      vertex -18.8657 8.26633 -16.5
     endloop
   endfacet
-  facet normal 0.993391 -0.114781 0
+  facet normal 0.0621747 -0.998065 0
     outer loop
-      vertex 19.3823 4.95499 16.5
-      vertex 19.3573 4.73854 17
-      vertex 19.3573 4.73854 16.5
-    endloop
-  endfacet
-  facet normal 0.921012 -0.389534 0
-    outer loop
-      vertex 19.2823 4.56122 17
-      vertex 19.3573 4.73854 16.5
-      vertex 19.3573 4.73854 17
-    endloop
-  endfacet
-  facet normal 0.921012 -0.389534 0
-    outer loop
-      vertex 19.3573 4.73854 16.5
-      vertex 19.2823 4.56122 17
-      vertex 19.2823 4.56122 16.5
-    endloop
-  endfacet
-  facet normal 0.741708 -0.670722 0
-    outer loop
-      vertex 19.1573 4.42299 17
-      vertex 19.2823 4.56122 16.5
-      vertex 19.2823 4.56122 17
-    endloop
-  endfacet
-  facet normal 0.741708 -0.670722 0
-    outer loop
-      vertex 19.2823 4.56122 16.5
-      vertex 19.1573 4.42299 17
-      vertex 19.1573 4.42299 16.5
-    endloop
-  endfacet
-  facet normal 0.482373 -0.875966 0
-    outer loop
-      vertex 18.9788 4.32466 16.5
-      vertex 19.1573 4.42299 17
-      vertex 18.9788 4.32466 17
-    endloop
-  endfacet
-  facet normal 0.482373 -0.875966 0
-    outer loop
-      vertex 19.1573 4.42299 17
-      vertex 18.9788 4.32466 16.5
-      vertex 19.1573 4.42299 16.5
-    endloop
-  endfacet
-  facet normal 0.241595 -0.970377 0
-    outer loop
-      vertex 18.7418 4.26566 16.5
-      vertex 18.9788 4.32466 17
-      vertex 18.7418 4.26566 17
-    endloop
-  endfacet
-  facet normal 0.241595 -0.970377 0
-    outer loop
-      vertex 18.9788 4.32466 17
-      vertex 18.7418 4.26566 16.5
-      vertex 18.9788 4.32466 16.5
-    endloop
-  endfacet
-  facet normal 0.0664267 -0.997791 0
-    outer loop
-      vertex 18.4463 4.24599 16.5
-      vertex 18.7418 4.26566 17
-      vertex 18.4463 4.24599 17
-    endloop
-  endfacet
-  facet normal 0.0664267 -0.997791 0
-    outer loop
-      vertex 18.7418 4.26566 17
-      vertex 18.4463 4.24599 16.5
-      vertex 18.7418 4.26566 16.5
+      vertex -18.3253 8.29999 -16.5
+      vertex -18.8657 8.26633 -17
+      vertex -18.3253 8.29999 -17
     endloop
   endfacet
   facet normal 0 -1 0
     outer loop
-      vertex 17.1253 4.24599 16.5
-      vertex 18.4463 4.24599 17
-      vertex 17.1253 4.24599 17
+      vertex -18.3253 8.29999 -17
+      vertex -16.1203 8.29999 -16.5
+      vertex -18.3253 8.29999 -16.5
     endloop
   endfacet
   facet normal 0 -1 -0
     outer loop
-      vertex 18.4463 4.24599 17
-      vertex 17.1253 4.24599 16.5
-      vertex 18.4463 4.24599 16.5
+      vertex -16.1203 8.29999 -16.5
+      vertex -18.3253 8.29999 -17
+      vertex -16.1203 8.29999 -17
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -16.1203 3.5 -17
+      vertex -16.1203 8.29999 -16.5
+      vertex -16.1203 8.29999 -17
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -16.1203 8.29999 -16.5
+      vertex -16.1203 3.5 -17
+      vertex -16.1203 3.5 -16.5
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -16.1203 3.5 -17
+      vertex -18.5303 3.5 -16.5
+      vertex -16.1203 3.5 -16.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -18.5303 3.5 -16.5
+      vertex -16.1203 3.5 -17
+      vertex -18.5303 3.5 -17
+    endloop
+  endfacet
+  facet normal 0.0737525 0.997277 -0
+    outer loop
+      vertex -18.5303 3.5 -17
+      vertex -19.0711 3.53999 -16.5
+      vertex -18.5303 3.5 -16.5
+    endloop
+  endfacet
+  facet normal 0.0737525 0.997277 0
+    outer loop
+      vertex -19.0711 3.53999 -16.5
+      vertex -18.5303 3.5 -17
+      vertex -19.0711 3.53999 -17
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -17.1253 6.37999 -16.5
+      vertex -17.1253 7.55399 -17
+      vertex -17.1253 7.55399 -16.5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -17.1253 7.55399 -17
+      vertex -17.1253 6.37999 -16.5
+      vertex -17.1253 6.37999 -17
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -17.1253 7.55399 -17
+      vertex -18.2783 7.55399 -16.5
+      vertex -17.1253 7.55399 -16.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -18.2783 7.55399 -16.5
+      vertex -17.1253 7.55399 -17
+      vertex -18.2783 7.55399 -17
+    endloop
+  endfacet
+  facet normal -0.0598353 0.998208 0
+    outer loop
+      vertex -18.2783 7.55399 -17
+      vertex -18.5286 7.53899 -16.5
+      vertex -18.2783 7.55399 -16.5
+    endloop
+  endfacet
+  facet normal -0.0598353 0.998208 0
+    outer loop
+      vertex -18.5286 7.53899 -16.5
+      vertex -18.2783 7.55399 -17
+      vertex -18.5286 7.53899 -17
+    endloop
+  endfacet
+  facet normal -0.214078 0.976817 0
+    outer loop
+      vertex -18.5286 7.53899 -17
+      vertex -18.7339 7.49399 -16.5
+      vertex -18.5286 7.53899 -16.5
+    endloop
+  endfacet
+  facet normal -0.214078 0.976817 0
+    outer loop
+      vertex -18.7339 7.49399 -16.5
+      vertex -18.5286 7.53899 -17
+      vertex -18.7339 7.49399 -17
+    endloop
+  endfacet
+  facet normal -0.423451 0.905919 0
+    outer loop
+      vertex -18.7339 7.49399 -17
+      vertex -18.8943 7.41899 -16.5
+      vertex -18.7339 7.49399 -16.5
+    endloop
+  endfacet
+  facet normal -0.423451 0.905919 0
+    outer loop
+      vertex -18.8943 7.41899 -16.5
+      vertex -18.7339 7.49399 -17
+      vertex -18.8943 7.41899 -17
+    endloop
+  endfacet
+  facet normal -0.689486 0.724299 0
+    outer loop
+      vertex -18.8943 7.41899 -17
+      vertex -19.0099 7.30899 -16.5
+      vertex -18.8943 7.41899 -16.5
+    endloop
+  endfacet
+  facet normal -0.689486 0.724299 0
+    outer loop
+      vertex -19.0099 7.30899 -16.5
+      vertex -18.8943 7.41899 -17
+      vertex -19.0099 7.30899 -17
+    endloop
+  endfacet
+  facet normal -0.909126 0.416522 0
+    outer loop
+      vertex -19.0792 7.15765 -17
+      vertex -19.0099 7.30899 -16.5
+      vertex -19.0099 7.30899 -17
+    endloop
+  endfacet
+  facet normal -0.909126 0.416522 0
+    outer loop
+      vertex -19.0099 7.30899 -16.5
+      vertex -19.0792 7.15765 -17
+      vertex -19.0792 7.15765 -16.5
+    endloop
+  endfacet
+  facet normal -0.992878 0.119136 0
+    outer loop
+      vertex -19.1023 6.965 -17
+      vertex -19.0792 7.15765 -16.5
+      vertex -19.0792 7.15765 -17
+    endloop
+  endfacet
+  facet normal -0.992878 0.119136 0
+    outer loop
+      vertex -19.0792 7.15765 -16.5
+      vertex -19.1023 6.965 -17
+      vertex -19.1023 6.965 -16.5
+    endloop
+  endfacet
+  facet normal -0.992789 -0.119878 0
+    outer loop
+      vertex -19.0808 6.78644 -17
+      vertex -19.1023 6.965 -16.5
+      vertex -19.1023 6.965 -17
+    endloop
+  endfacet
+  facet normal -0.992789 -0.119878 0
+    outer loop
+      vertex -19.1023 6.965 -16.5
+      vertex -19.0808 6.78644 -17
+      vertex -19.0808 6.78644 -16.5
+    endloop
+  endfacet
+  facet normal -0.914667 -0.404208 0
+    outer loop
+      vertex -19.0161 6.64011 -17
+      vertex -19.0808 6.78644 -16.5
+      vertex -19.0808 6.78644 -17
+    endloop
+  endfacet
+  facet normal -0.914667 -0.404208 0
+    outer loop
+      vertex -19.0808 6.78644 -16.5
+      vertex -19.0161 6.64011 -17
+      vertex -19.0161 6.64011 -16.5
+    endloop
+  endfacet
+  facet normal -0.727037 -0.686598 0
+    outer loop
+      vertex -18.9083 6.52599 -17
+      vertex -19.0161 6.64011 -16.5
+      vertex -19.0161 6.64011 -17
+    endloop
+  endfacet
+  facet normal -0.727037 -0.686598 0
+    outer loop
+      vertex -19.0161 6.64011 -16.5
+      vertex -18.9083 6.52599 -17
+      vertex -18.9083 6.52599 -16.5
+    endloop
+  endfacet
+  facet normal -0.462569 -0.886583 0
+    outer loop
+      vertex -18.9083 6.52599 -17
+      vertex -18.7529 6.44489 -16.5
+      vertex -18.9083 6.52599 -16.5
+    endloop
+  endfacet
+  facet normal -0.462569 -0.886583 -0
+    outer loop
+      vertex -18.7529 6.44489 -16.5
+      vertex -18.9083 6.52599 -17
+      vertex -18.7529 6.44489 -17
+    endloop
+  endfacet
+  facet normal -0.228202 -0.973614 0
+    outer loop
+      vertex -18.7529 6.44489 -17
+      vertex -18.5452 6.39621 -16.5
+      vertex -18.7529 6.44489 -16.5
+    endloop
+  endfacet
+  facet normal -0.228202 -0.973614 -0
+    outer loop
+      vertex -18.5452 6.39621 -16.5
+      vertex -18.7529 6.44489 -17
+      vertex -18.5452 6.39621 -17
+    endloop
+  endfacet
+  facet normal -0.0622907 -0.998058 0
+    outer loop
+      vertex -18.5452 6.39621 -17
+      vertex -18.2853 6.37999 -16.5
+      vertex -18.5452 6.39621 -16.5
+    endloop
+  endfacet
+  facet normal -0.0622907 -0.998058 -0
+    outer loop
+      vertex -18.2853 6.37999 -16.5
+      vertex -18.5452 6.39621 -17
+      vertex -18.2853 6.37999 -17
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -18.2853 6.37999 -17
+      vertex -17.1253 6.37999 -16.5
+      vertex -18.2853 6.37999 -16.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -17.1253 6.37999 -16.5
+      vertex -18.2853 6.37999 -17
+      vertex -17.1253 6.37999 -17
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex -17.1253 4.24599 -16.5
+      vertex -17.1253 5.63699 -17
+      vertex -17.1253 5.63699 -16.5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex -17.1253 5.63699 -17
+      vertex -17.1253 4.24599 -16.5
+      vertex -17.1253 4.24599 -17
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex -17.1253 5.63699 -17
+      vertex -18.4083 5.63699 -16.5
+      vertex -17.1253 5.63699 -16.5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex -18.4083 5.63699 -16.5
+      vertex -17.1253 5.63699 -17
+      vertex -18.4083 5.63699 -17
+    endloop
+  endfacet
+  facet normal -0.138684 0.990337 0
+    outer loop
+      vertex -18.4083 5.63699 -17
+      vertex -18.9494 5.56122 -16.5
+      vertex -18.4083 5.63699 -16.5
+    endloop
+  endfacet
+  facet normal -0.138684 0.990337 0
+    outer loop
+      vertex -18.9494 5.56122 -16.5
+      vertex -18.4083 5.63699 -17
+      vertex -18.9494 5.56122 -17
+    endloop
+  endfacet
+  facet normal -0.573594 0.81914 0
+    outer loop
+      vertex -18.9494 5.56122 -17
+      vertex -19.2741 5.33388 -16.5
+      vertex -18.9494 5.56122 -16.5
+    endloop
+  endfacet
+  facet normal -0.573594 0.81914 0
+    outer loop
+      vertex -19.2741 5.33388 -16.5
+      vertex -18.9494 5.56122 -17
+      vertex -19.2741 5.33388 -17
+    endloop
+  endfacet
+  facet normal -0.96154 0.274665 0
+    outer loop
+      vertex -19.3823 4.95499 -17
+      vertex -19.2741 5.33388 -16.5
+      vertex -19.2741 5.33388 -17
+    endloop
+  endfacet
+  facet normal -0.96154 0.274665 0
+    outer loop
+      vertex -19.2741 5.33388 -16.5
+      vertex -19.3823 4.95499 -17
+      vertex -19.3823 4.95499 -16.5
+    endloop
+  endfacet
+  facet normal -0.993391 -0.114781 0
+    outer loop
+      vertex -19.3573 4.73854 -17
+      vertex -19.3823 4.95499 -16.5
+      vertex -19.3823 4.95499 -17
+    endloop
+  endfacet
+  facet normal -0.993391 -0.114781 0
+    outer loop
+      vertex -19.3823 4.95499 -16.5
+      vertex -19.3573 4.73854 -17
+      vertex -19.3573 4.73854 -16.5
+    endloop
+  endfacet
+  facet normal -0.921012 -0.389534 0
+    outer loop
+      vertex -19.2823 4.56122 -17
+      vertex -19.3573 4.73854 -16.5
+      vertex -19.3573 4.73854 -17
+    endloop
+  endfacet
+  facet normal -0.921012 -0.389534 0
+    outer loop
+      vertex -19.3573 4.73854 -16.5
+      vertex -19.2823 4.56122 -17
+      vertex -19.2823 4.56122 -16.5
+    endloop
+  endfacet
+  facet normal -0.741708 -0.670722 0
+    outer loop
+      vertex -19.1573 4.42299 -17
+      vertex -19.2823 4.56122 -16.5
+      vertex -19.2823 4.56122 -17
+    endloop
+  endfacet
+  facet normal -0.741708 -0.670722 0
+    outer loop
+      vertex -19.2823 4.56122 -16.5
+      vertex -19.1573 4.42299 -17
+      vertex -19.1573 4.42299 -16.5
+    endloop
+  endfacet
+  facet normal -0.482373 -0.875966 0
+    outer loop
+      vertex -19.1573 4.42299 -17
+      vertex -18.9788 4.32466 -16.5
+      vertex -19.1573 4.42299 -16.5
+    endloop
+  endfacet
+  facet normal -0.482373 -0.875966 -0
+    outer loop
+      vertex -18.9788 4.32466 -16.5
+      vertex -19.1573 4.42299 -17
+      vertex -18.9788 4.32466 -17
+    endloop
+  endfacet
+  facet normal -0.241595 -0.970377 0
+    outer loop
+      vertex -18.9788 4.32466 -17
+      vertex -18.7418 4.26566 -16.5
+      vertex -18.9788 4.32466 -16.5
+    endloop
+  endfacet
+  facet normal -0.241595 -0.970377 -0
+    outer loop
+      vertex -18.7418 4.26566 -16.5
+      vertex -18.9788 4.32466 -17
+      vertex -18.7418 4.26566 -17
+    endloop
+  endfacet
+  facet normal -0.0664267 -0.997791 0
+    outer loop
+      vertex -18.7418 4.26566 -17
+      vertex -18.4463 4.24599 -16.5
+      vertex -18.7418 4.26566 -16.5
+    endloop
+  endfacet
+  facet normal -0.0664267 -0.997791 -0
+    outer loop
+      vertex -18.4463 4.24599 -16.5
+      vertex -18.7418 4.26566 -17
+      vertex -18.4463 4.24599 -17
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex -18.4463 4.24599 -17
+      vertex -17.1253 4.24599 -16.5
+      vertex -18.4463 4.24599 -16.5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex -17.1253 4.24599 -16.5
+      vertex -18.4463 4.24599 -17
+      vertex -17.1253 4.24599 -17
     endloop
   endfacet
 endsolid OpenSCAD_Model


### PR DESCRIPTION
Similar fix to the Haribo nozzle within the base STL folder.

- First changeset just formats the scad document for indentation, my OCD got the better of me
- Second changeset adds a new module that simply flips the model 180 degrees so it will generate a printable STL file and update the STL file based on the new code.